### PR TITLE
Implement GPT queue, response handling and config rollback

### DIFF
--- a/src/main/java/com/illusioncis7/opencore/OpenCore.java
+++ b/src/main/java/com/illusioncis7/opencore/OpenCore.java
@@ -3,6 +3,8 @@ package com.illusioncis7.opencore;
 import com.illusioncis7.opencore.database.Database;
 import com.illusioncis7.opencore.logging.ChatLogger;
 import com.illusioncis7.opencore.gpt.GptService;
+import com.illusioncis7.opencore.gpt.GptQueueManager;
+import com.illusioncis7.opencore.gpt.GptResponseHandler;
 import com.illusioncis7.opencore.config.ConfigService;
 import com.illusioncis7.opencore.reputation.ReputationService;
 import com.illusioncis7.opencore.reputation.PlayerJoinListener;
@@ -12,6 +14,7 @@ import com.illusioncis7.opencore.voting.command.SuggestionsCommand;
 import com.illusioncis7.opencore.voting.command.VoteCommand;
 import com.illusioncis7.opencore.rules.RuleService;
 import com.illusioncis7.opencore.rules.command.RulesCommand;
+import com.illusioncis7.opencore.config.command.RollbackConfigCommand;
 import com.illusioncis7.opencore.plan.PlanHook;
 import java.io.File;
 import java.util.Objects;
@@ -23,6 +26,8 @@ public class OpenCore extends JavaPlugin {
     private static OpenCore instance;
     private Database database;
     private GptService gptService;
+    private GptQueueManager gptQueueManager;
+    private GptResponseHandler gptResponseHandler;
     private ConfigService configService;
     private RuleService ruleService;
     private ReputationService reputationService;
@@ -54,6 +59,9 @@ public class OpenCore extends JavaPlugin {
 
         gptService = new GptService(this, database);
         gptService.init();
+        gptResponseHandler = new GptResponseHandler(this, database);
+        gptQueueManager = new GptQueueManager(this, gptService, gptResponseHandler);
+        gptQueueManager.start();
 
         planHook = new PlanHook();
         if (planHook.hook()) {
@@ -67,12 +75,14 @@ public class OpenCore extends JavaPlugin {
         Objects.requireNonNull(getCommand("suggestions")).setExecutor(new SuggestionsCommand(votingService));
         Objects.requireNonNull(getCommand("vote")).setExecutor(new VoteCommand(votingService));
         Objects.requireNonNull(getCommand("rules")).setExecutor(new RulesCommand(ruleService));
+        Objects.requireNonNull(getCommand("rollbackconfig")).setExecutor(new RollbackConfigCommand(configService));
 
         new com.illusioncis7.opencore.reputation.ChatAnalyzerTask(database, gptService, reputationService, getLogger())
                 .runTaskTimerAsynchronously(this, 0L, 30 * 60 * 20L);
 
         getServer().getPluginManager().registerEvents(new ChatLogger(database, getLogger()), this);
         getServer().getPluginManager().registerEvents(new PlayerJoinListener(reputationService, getLogger()), this);
+        getServer().getPluginManager().registerEvents(gptResponseHandler, this);
     }
 
     @Override
@@ -82,6 +92,9 @@ public class OpenCore extends JavaPlugin {
         }
         if (gptService != null) {
             gptService.shutdown();
+        }
+        if (gptQueueManager != null) {
+            gptQueueManager.stop();
         }
     }
 

--- a/src/main/java/com/illusioncis7/opencore/config/ConfigChangeHistory.java
+++ b/src/main/java/com/illusioncis7/opencore/config/ConfigChangeHistory.java
@@ -1,0 +1,25 @@
+package com.illusioncis7.opencore.config;
+
+import java.sql.Timestamp;
+import java.util.UUID;
+
+/**
+ * Represents an applied configuration change for audit and rollback purposes.
+ */
+public class ConfigChangeHistory {
+    public final UUID changeId;
+    public final UUID playerUuid;
+    public final String paramKey;
+    public final Object oldValue;
+    public final Object newValue;
+    public final Timestamp changedAt;
+
+    public ConfigChangeHistory(UUID changeId, UUID playerUuid, String paramKey, Object oldValue, Object newValue, Timestamp changedAt) {
+        this.changeId = changeId;
+        this.playerUuid = playerUuid;
+        this.paramKey = paramKey;
+        this.oldValue = oldValue;
+        this.newValue = newValue;
+        this.changedAt = changedAt;
+    }
+}

--- a/src/main/java/com/illusioncis7/opencore/config/ConfigParameter.java
+++ b/src/main/java/com/illusioncis7/opencore/config/ConfigParameter.java
@@ -4,8 +4,8 @@ public class ConfigParameter {
     private int id;
     private String path;
     private String parameterPath;
-    private String minValue;
-    private String maxValue;
+    private int minValue;
+    private int maxValue;
     private String description;
     private String recommendedRange;
     private boolean editable;
@@ -43,19 +43,19 @@ public class ConfigParameter {
         this.parameterPath = parameterPath;
     }
 
-    public String getMinValue() {
+    public int getMinValue() {
         return minValue;
     }
 
-    public void setMinValue(String minValue) {
+    public void setMinValue(int minValue) {
         this.minValue = minValue;
     }
 
-    public String getMaxValue() {
+    public int getMaxValue() {
         return maxValue;
     }
 
-    public void setMaxValue(String maxValue) {
+    public void setMaxValue(int maxValue) {
         this.maxValue = maxValue;
     }
 
@@ -97,5 +97,43 @@ public class ConfigParameter {
 
     public void setImpactRating(int impactRating) {
         this.impactRating = impactRating;
+    }
+
+    /**
+     * Validate the provided value against this parameter's constraints.
+     *
+     * @param value value to check
+     * @return {@code true} if valid
+     */
+    public boolean isValid(Object value) {
+        if (value == null) {
+            return false;
+        }
+        try {
+            int v;
+            if (value instanceof Number) {
+                v = ((Number) value).intValue();
+            } else {
+                v = Integer.parseInt(value.toString());
+            }
+            return v >= minValue && v <= maxValue;
+        } catch (NumberFormatException e) {
+            return false;
+        }
+    }
+
+    /**
+     * Return validation warnings for a value if it violates constraints.
+     */
+    public String getValidationWarnings(Object value) {
+        StringBuilder sb = new StringBuilder();
+        if (!editable) {
+            sb.append("Parameter not editable");
+        }
+        if (!isValid(value)) {
+            if (sb.length() > 0) sb.append("; ");
+            sb.append("Value outside allowed range [").append(minValue).append("-").append(maxValue).append("]");
+        }
+        return sb.toString();
     }
 }

--- a/src/main/java/com/illusioncis7/opencore/config/ConfigService.java
+++ b/src/main/java/com/illusioncis7/opencore/config/ConfigService.java
@@ -17,6 +17,8 @@ import java.sql.SQLException;
 import java.sql.Types;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
+import java.sql.Timestamp;
 
 /**
  * Scans configuration files and allows updates of single parameters.
@@ -127,7 +129,7 @@ public class ConfigService {
     /**
      * Update a configuration parameter by ID with a new value.
      */
-    public boolean updateParameter(int id, String newValue) {
+    public boolean updateParameter(int id, String newValue, UUID changedBy) {
         if (database.getConnection() == null) {
             return false;
         }
@@ -141,7 +143,13 @@ public class ConfigService {
                 if (rs.next()) {
                     String path = rs.getString(1);
                     String param = rs.getString(2);
-                    return updateFile(new File(path), param, newValue);
+                    File file = new File(path);
+                    Object oldVal = loadValue(file, param);
+                    boolean ok = updateFile(file, param, newValue);
+                    if (ok) {
+                        logChange(id, oldVal, newValue, changedBy);
+                    }
+                    return ok;
                 }
             }
         } catch (SQLException e) {
@@ -193,6 +201,70 @@ public class ConfigService {
             } catch (IOException e) {
                 plugin.getLogger().severe("Failed to update conf file " + file + ": " + e.getMessage());
             }
+        }
+        return false;
+    }
+
+    private Object loadValue(File file, String parameterPath) {
+        try {
+            if (file.getName().toLowerCase().endsWith(".yml")) {
+                FileConfiguration cfg = YamlConfiguration.loadConfiguration(file);
+                return cfg.get(parameterPath);
+            } else if (file.getName().toLowerCase().endsWith(".conf")) {
+                try (BufferedReader br = new BufferedReader(new FileReader(file))) {
+                    String line;
+                    while ((line = br.readLine()) != null) {
+                        if (line.startsWith(parameterPath + "=")) {
+                            return line.substring(parameterPath.length() + 1).trim();
+                        }
+                    }
+                }
+            }
+        } catch (IOException e) {
+            plugin.getLogger().warning("Failed to read config value: " + e.getMessage());
+        }
+        return null;
+    }
+
+    private void logChange(int paramId, Object oldVal, Object newVal, UUID player) {
+        if (database.getConnection() == null) return;
+        String sql = "INSERT INTO config_change_history (change_id, player_uuid, param_key, old_value, new_value, changed_at) VALUES (?, ?, ?, ?, ?, ?)";
+        try (Connection conn = database.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setString(1, UUID.randomUUID().toString());
+            if (player != null) {
+                ps.setString(2, player.toString());
+            } else {
+                ps.setNull(2, Types.VARCHAR);
+            }
+            ps.setString(3, String.valueOf(paramId));
+            ps.setString(4, oldVal != null ? oldVal.toString() : null);
+            ps.setString(5, newVal != null ? newVal.toString() : null);
+            ps.setTimestamp(6, new Timestamp(System.currentTimeMillis()));
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            plugin.getLogger().warning("Failed to log config change: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Rollback a change by applying the stored old value.
+     */
+    public boolean rollbackChange(UUID changeId) {
+        if (database.getConnection() == null) return false;
+        String sql = "SELECT param_key, old_value FROM config_change_history WHERE change_id = ?";
+        try (Connection conn = database.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setString(1, changeId.toString());
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    int paramId = Integer.parseInt(rs.getString(1));
+                    String oldVal = rs.getString(2);
+                    return updateParameter(paramId, oldVal, null);
+                }
+            }
+        } catch (Exception e) {
+            plugin.getLogger().warning("Failed to rollback config: " + e.getMessage());
         }
         return false;
     }

--- a/src/main/java/com/illusioncis7/opencore/config/command/RollbackConfigCommand.java
+++ b/src/main/java/com/illusioncis7/opencore/config/command/RollbackConfigCommand.java
@@ -1,0 +1,39 @@
+package com.illusioncis7.opencore.config.command;
+
+import com.illusioncis7.opencore.config.ConfigService;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+
+import java.util.UUID;
+
+/**
+ * Command to rollback a configuration change by id.
+ */
+public class RollbackConfigCommand implements CommandExecutor {
+
+    private final ConfigService configService;
+
+    public RollbackConfigCommand(ConfigService configService) {
+        this.configService = configService;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (args.length < 1) {
+            sender.sendMessage("Usage: /rollbackconfig <changeId>");
+            return true;
+        }
+        try {
+            UUID id = UUID.fromString(args[0]);
+            if (configService.rollbackChange(id)) {
+                sender.sendMessage("Rollback executed.");
+            } else {
+                sender.sendMessage("Rollback failed.");
+            }
+        } catch (IllegalArgumentException e) {
+            sender.sendMessage("Invalid id.");
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/illusioncis7/opencore/database/Database.java
+++ b/src/main/java/com/illusioncis7/opencore/database/Database.java
@@ -63,8 +63,8 @@ public class Database {
                     "id INT AUTO_INCREMENT PRIMARY KEY," +
                     "path VARCHAR(255) NOT NULL," +
                     "parameter_path VARCHAR(255) NOT NULL," +
-                    "min_value VARCHAR(255)," +
-                    "max_value VARCHAR(255)," +
+                    "min_value INT," +
+                    "max_value INT," +
                     "recommended_range VARCHAR(255)," +
                     "editable BOOLEAN DEFAULT 0," +
                     "impact_category VARCHAR(50)," +
@@ -133,6 +133,16 @@ public class Database {
                     ")";
             stmt.executeUpdate(promptSql);
 
+            String responseSql = "CREATE TABLE IF NOT EXISTS gpt_responses (" +
+                    "id INT AUTO_INCREMENT PRIMARY KEY," +
+                    "player_uuid VARCHAR(36) NOT NULL," +
+                    "module VARCHAR(50)," +
+                    "response TEXT NOT NULL," +
+                    "created TIMESTAMP NOT NULL," +
+                    "delivered BOOLEAN DEFAULT 0" +
+                    ")";
+            stmt.executeUpdate(responseSql);
+
             String rulesSql = "CREATE TABLE IF NOT EXISTS server_rules (" +
                     "id INT AUTO_INCREMENT PRIMARY KEY," +
                     "rule_text TEXT NOT NULL" +
@@ -149,6 +159,16 @@ public class Database {
                     "suggestion_id INT" +
                     ")";
             stmt.executeUpdate(ruleLogSql);
+
+            String cfgHistSql = "CREATE TABLE IF NOT EXISTS config_change_history (" +
+                    "change_id VARCHAR(36) PRIMARY KEY," +
+                    "player_uuid VARCHAR(36)," +
+                    "param_key VARCHAR(255) NOT NULL," +
+                    "old_value TEXT," +
+                    "new_value TEXT," +
+                    "changed_at TIMESTAMP NOT NULL" +
+                    ")";
+            stmt.executeUpdate(cfgHistSql);
         }
     }
 

--- a/src/main/java/com/illusioncis7/opencore/gpt/GptQueueManager.java
+++ b/src/main/java/com/illusioncis7/opencore/gpt/GptQueueManager.java
@@ -1,0 +1,73 @@
+package com.illusioncis7.opencore.gpt;
+
+import org.bukkit.Bukkit;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.scheduler.BukkitTask;
+
+import java.util.Queue;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.logging.Logger;
+
+/**
+ * Handles GPT requests with a fixed rate to avoid API flooding.
+ */
+public class GptQueueManager {
+
+    private final JavaPlugin plugin;
+    private final GptService gptService;
+    private final GptResponseHandler responseHandler;
+    private final Queue<GptRequest> queue = new ConcurrentLinkedQueue<>();
+    private BukkitTask task;
+    private final Logger logger;
+
+    public GptQueueManager(JavaPlugin plugin, GptService gptService, GptResponseHandler responseHandler) {
+        this.plugin = plugin;
+        this.gptService = gptService;
+        this.responseHandler = responseHandler;
+        this.logger = plugin.getLogger();
+    }
+
+    /**
+     * Start processing queued requests every 10 minutes.
+     */
+    public void start() {
+        if (task != null) {
+            return;
+        }
+        task = Bukkit.getScheduler().runTaskTimerAsynchronously(plugin, this::processNext, 0L, 10 * 60 * 20L);
+    }
+
+    /**
+     * Stop processing and clear the queue.
+     */
+    public void stop() {
+        if (task != null) {
+            task.cancel();
+            task = null;
+        }
+        queue.clear();
+    }
+
+    /**
+     * Queue a new GPT request.
+     */
+    public void submit(String module, String prompt, UUID player) {
+        GptRequest req = new GptRequest(UUID.randomUUID(), module, prompt, player, null);
+        queue.add(req);
+        logger.info("Queued GPT request " + req.requestId + " from " + module);
+    }
+
+    private void processNext() {
+        GptRequest req = queue.poll();
+        if (req == null) {
+            return;
+        }
+        logger.info("Processing queued GPT request " + req.requestId);
+        gptService.submitRequest(req.prompt, req.playerUuid, response -> {
+            if (responseHandler != null) {
+                responseHandler.handleResponse(req, response);
+            }
+        });
+    }
+}

--- a/src/main/java/com/illusioncis7/opencore/gpt/GptRequest.java
+++ b/src/main/java/com/illusioncis7/opencore/gpt/GptRequest.java
@@ -5,15 +5,39 @@ import java.util.function.Consumer;
 
 public class GptRequest {
 
+    /** Unique request id. */
     public final UUID requestId;
+    /** Optional module that created the request. */
+    public final String module;
+    /** Prompt text sent to GPT. */
     public final String prompt;
+    /** Player related to the request or {@code null}. */
     public final UUID playerUuid;
+    /** Callback for the response. */
     public final Consumer<String> callback;
 
-    public GptRequest(UUID requestId, String prompt, UUID playerUuid, Consumer<String> callback) {
+    /**
+     * Creates a new request.
+     *
+     * @param requestId unique id
+     * @param module    module name (may be {@code null})
+     * @param prompt    prompt text
+     * @param playerUuid related player or {@code null}
+     * @param callback  response callback
+     */
+    public GptRequest(UUID requestId, String module, String prompt, UUID playerUuid,
+                      Consumer<String> callback) {
         this.requestId = requestId;
+        this.module = module;
         this.prompt = prompt;
         this.playerUuid = playerUuid;
         this.callback = callback;
+    }
+
+    /**
+     * Convenience constructor without module.
+     */
+    public GptRequest(UUID requestId, String prompt, UUID playerUuid, Consumer<String> callback) {
+        this(requestId, null, prompt, playerUuid, callback);
     }
 }

--- a/src/main/java/com/illusioncis7/opencore/gpt/GptResponseHandler.java
+++ b/src/main/java/com/illusioncis7/opencore/gpt/GptResponseHandler.java
@@ -1,0 +1,111 @@
+package com.illusioncis7.opencore.gpt;
+
+import com.illusioncis7.opencore.database.Database;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.util.UUID;
+import java.util.logging.Logger;
+
+/**
+ * Stores GPT responses for offline players and delivers them on login.
+ */
+public class GptResponseHandler implements Listener {
+
+    private final JavaPlugin plugin;
+    private final Database database;
+    private final Logger logger;
+
+    public GptResponseHandler(JavaPlugin plugin, Database database) {
+        this.plugin = plugin;
+        this.database = database;
+        this.logger = plugin.getLogger();
+    }
+
+    /**
+     * Handle a response for the given request.
+     */
+    public void handleResponse(GptRequest request, String response) {
+        if (response == null || request.playerUuid == null) {
+            return;
+        }
+        Player player = Bukkit.getPlayer(request.playerUuid);
+        if (player != null && player.isOnline()) {
+            player.sendMessage(response);
+        } else {
+            storeResponse(request.playerUuid, request.module, response);
+        }
+    }
+
+    private void storeResponse(UUID uuid, String module, String response) {
+        if (database.getConnection() == null) {
+            return;
+        }
+        String sql = "INSERT INTO gpt_responses (player_uuid, module, response, created, delivered) VALUES (?, ?, ?, ?, 0)";
+        try (Connection conn = database.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setString(1, uuid.toString());
+            if (module != null) {
+                ps.setString(2, module);
+            } else {
+                ps.setNull(2, Types.VARCHAR);
+            }
+            ps.setString(3, response);
+            ps.setTimestamp(4, new Timestamp(System.currentTimeMillis()));
+            ps.executeUpdate();
+        } catch (Exception e) {
+            logger.warning("Failed to store GPT response: " + e.getMessage());
+        }
+    }
+
+    @EventHandler
+    public void onPlayerJoin(PlayerJoinEvent event) {
+        UUID uuid = event.getPlayer().getUniqueId();
+        deliverPending(uuid, event.getPlayer());
+    }
+
+    private void deliverPending(UUID uuid, Player player) {
+        if (database.getConnection() == null) return;
+        String sql = "SELECT id, module, response FROM gpt_responses WHERE player_uuid = ? AND delivered = 0";
+        try (Connection conn = database.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setString(1, uuid.toString());
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    int id = rs.getInt(1);
+                    String module = rs.getString(2);
+                    String text = rs.getString(3);
+                    if (module != null && !module.isEmpty()) {
+                        player.sendMessage("[" + module + "] " + text);
+                    } else {
+                        player.sendMessage(text);
+                    }
+                    markDelivered(id);
+                }
+            }
+        } catch (Exception e) {
+            logger.warning("Failed to deliver GPT responses: " + e.getMessage());
+        }
+    }
+
+    private void markDelivered(int id) {
+        if (database.getConnection() == null) return;
+        String sql = "UPDATE gpt_responses SET delivered = 1 WHERE id = ?";
+        try (Connection conn = database.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setInt(1, id);
+            ps.executeUpdate();
+        } catch (Exception e) {
+            logger.warning("Failed to mark response delivered: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/illusioncis7/opencore/voting/VotingService.java
+++ b/src/main/java/com/illusioncis7/opencore/voting/VotingService.java
@@ -340,7 +340,7 @@ public class VotingService {
         if (value == null) return;
         boolean updated = false;
         if (type == SuggestionType.CONFIG_CHANGE) {
-            updated = configService.updateParameter(paramId, value);
+            updated = configService.updateParameter(paramId, value, player);
         } else if (type == SuggestionType.RULE_CHANGE) {
             updated = ruleService.updateRule(paramId, value, player, suggestionId);
         }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -12,3 +12,5 @@ commands:
     description: Vote on a suggestion
   rules:
     description: List server rules
+  rollbackconfig:
+    description: Roll back a configuration change


### PR DESCRIPTION
## Summary
- manage GPT calls via new `GptQueueManager`
- store undelivered GPT answers and send them on player join
- extend config parameter validation and add change history
- allow rolling back config changes with `/rollbackconfig`

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_68449c7468dc8323b11420d7a7708104