### PR TITLE
Add player suggestion and voting commands

### DIFF
--- a/src/main/java/com/illusioncis7/opencore/rules/RuleService.java
+++ b/src/main/java/com/illusioncis7/opencore/rules/RuleService.java
@@ -37,6 +37,23 @@ public class RuleService {
         return list;
     }
 
+    public Rule getRule(int id) {
+        if (database.getConnection() == null) return null;
+        String sql = "SELECT id, rule_text FROM server_rules WHERE id = ?";
+        try (Connection conn = database.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setInt(1, id);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    return new Rule(rs.getInt(1), rs.getString(2));
+                }
+            }
+        } catch (SQLException e) {
+            logger.warning("Failed to load rule: " + e.getMessage());
+        }
+        return null;
+    }
+
     public boolean updateRule(int id, String newText, UUID changedBy, Integer suggestionId) {
         if (database.getConnection() == null) return false;
         String selectSql = "SELECT rule_text FROM server_rules WHERE id = ?";

--- a/src/main/java/com/illusioncis7/opencore/rules/command/RulesCommand.java
+++ b/src/main/java/com/illusioncis7/opencore/rules/command/RulesCommand.java
@@ -17,6 +17,21 @@ public class RulesCommand implements CommandExecutor {
 
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (args.length == 1) {
+            try {
+                int id = Integer.parseInt(args[0]);
+                Rule r = ruleService.getRule(id);
+                if (r == null) {
+                    sender.sendMessage("Rule not found.");
+                } else {
+                    sender.sendMessage("#" + r.id + ": " + r.text);
+                }
+            } catch (NumberFormatException e) {
+                sender.sendMessage("Invalid id.");
+            }
+            return true;
+        }
+
         List<Rule> rules = ruleService.getRules();
         if (rules.isEmpty()) {
             sender.sendMessage("No rules defined.");

--- a/src/main/java/com/illusioncis7/opencore/voting/command/SuggestCommand.java
+++ b/src/main/java/com/illusioncis7/opencore/voting/command/SuggestCommand.java
@@ -1,5 +1,6 @@
 package com.illusioncis7.opencore.voting.command;
 
+import com.illusioncis7.opencore.OpenCore;
 import com.illusioncis7.opencore.voting.VotingService;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
@@ -23,9 +24,18 @@ public class SuggestCommand implements CommandExecutor {
             sender.sendMessage("Usage: /suggest <text>");
             return true;
         }
-        String text = String.join(" ", args);
-        votingService.submitSuggestion(((Player) sender).getUniqueId(), text);
-        sender.sendMessage("Suggestion submitted.");
+        String text = String.join(" ", args).trim();
+        if (text.length() < 5) {
+            sender.sendMessage("Suggestion too short.");
+            OpenCore.getInstance().getLogger().warning("Rejected short suggestion from " + sender.getName());
+            return true;
+        }
+        int id = votingService.submitSuggestion(((Player) sender).getUniqueId(), text);
+        if (id == -1) {
+            sender.sendMessage("Failed to submit suggestion.");
+        } else {
+            sender.sendMessage("Suggestion submitted with ID " + id + ".");
+        }
         return true;
     }
 }

--- a/src/main/java/com/illusioncis7/opencore/voting/command/SuggestionsCommand.java
+++ b/src/main/java/com/illusioncis7/opencore/voting/command/SuggestionsCommand.java
@@ -2,6 +2,7 @@ package com.illusioncis7.opencore.voting.command;
 
 import com.illusioncis7.opencore.voting.Suggestion;
 import com.illusioncis7.opencore.voting.VotingService;
+import com.illusioncis7.opencore.voting.VotingService.VoteWeights;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
@@ -23,8 +24,10 @@ public class SuggestionsCommand implements CommandExecutor {
             return true;
         }
         for (Suggestion s : list) {
-            String desc = s.description != null ? s.description : "n/a";
-            sender.sendMessage("#" + s.id + " -> param " + s.parameterId + " (" + desc + ") = " + s.newValue + " (" + s.text + ")");
+            VoteWeights w = votingService.getVoteWeights(s.id);
+            int remaining = Math.max(0, w.requiredWeight - w.yesWeight);
+            String title = (s.description != null && !s.description.isEmpty()) ? s.description : s.text;
+            sender.sendMessage("#" + s.id + " - " + title + " [" + w.yesWeight + "/" + w.requiredWeight + " yes] " + remaining + " votes needed");
         }
         return true;
     }

--- a/src/main/java/com/illusioncis7/opencore/voting/command/VoteCommand.java
+++ b/src/main/java/com/illusioncis7/opencore/voting/command/VoteCommand.java
@@ -1,5 +1,6 @@
 package com.illusioncis7.opencore.voting.command;
 
+import com.illusioncis7.opencore.OpenCore;
 import com.illusioncis7.opencore.voting.VotingService;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
@@ -26,8 +27,17 @@ public class VoteCommand implements CommandExecutor {
         try {
             int id = Integer.parseInt(args[0]);
             boolean yes = args[1].equalsIgnoreCase("yes") || args[1].equalsIgnoreCase("y");
-            votingService.castVote(((Player) sender).getUniqueId(), id, yes);
-            sender.sendMessage("Vote recorded.");
+            boolean success = votingService.castVote(((Player) sender).getUniqueId(), id, yes);
+            if (!success) {
+                sender.sendMessage("Unknown or closed suggestion.");
+                OpenCore.getInstance().getLogger().warning("Invalid vote from " + sender.getName() + " for " + id);
+                return true;
+            }
+            if (votingService.isSuggestionOpen(id)) {
+                sender.sendMessage("Vote registered.");
+            } else {
+                sender.sendMessage("Voting concluded.");
+            }
         } catch (NumberFormatException e) {
             sender.sendMessage("Invalid id.");
         }


### PR DESCRIPTION
## Summary
- allow players to suggest rule/config changes with `/suggest`
- validate proposals and show suggestion ID
- handle weighted voting and show results using `/vote`
- list current suggestions including required votes
- show single rules by id
- expose helpers in `VotingService` and `RuleService`

## Testing
- `mvn -q test` *(fails: PluginResolutionException)*

------
https://chatgpt.com/codex/tasks/task_e_6844a0b4550483238bd0e433b03c2a55