### PR TITLE
Add player transparency commands

### DIFF
--- a/src/main/java/com/illusioncis7/opencore/OpenCore.java
+++ b/src/main/java/com/illusioncis7/opencore/OpenCore.java
@@ -76,6 +76,9 @@ public class OpenCore extends JavaPlugin {
         Objects.requireNonNull(getCommand("vote")).setExecutor(new VoteCommand(votingService));
         Objects.requireNonNull(getCommand("rules")).setExecutor(new RulesCommand(ruleService));
         Objects.requireNonNull(getCommand("rollbackconfig")).setExecutor(new RollbackConfigCommand(configService));
+        Objects.requireNonNull(getCommand("myrep")).setExecutor(new com.illusioncis7.opencore.reputation.command.MyRepCommand(reputationService));
+        Objects.requireNonNull(getCommand("gptlog")).setExecutor(new com.illusioncis7.opencore.gpt.command.GptLogCommand(gptResponseHandler));
+        Objects.requireNonNull(getCommand("repinfo")).setExecutor(new com.illusioncis7.opencore.reputation.command.RepInfoCommand(reputationService));
 
         new com.illusioncis7.opencore.reputation.ChatAnalyzerTask(database, gptService, reputationService, getLogger())
                 .runTaskTimerAsynchronously(this, 0L, 30 * 60 * 20L);

--- a/src/main/java/com/illusioncis7/opencore/gpt/GptResponseRecord.java
+++ b/src/main/java/com/illusioncis7/opencore/gpt/GptResponseRecord.java
@@ -1,0 +1,15 @@
+package com.illusioncis7.opencore.gpt;
+
+import java.time.Instant;
+
+public class GptResponseRecord {
+    public final String module;
+    public final String response;
+    public final Instant timestamp;
+
+    public GptResponseRecord(String module, String response, Instant timestamp) {
+        this.module = module;
+        this.response = response;
+        this.timestamp = timestamp;
+    }
+}

--- a/src/main/java/com/illusioncis7/opencore/gpt/command/GptLogCommand.java
+++ b/src/main/java/com/illusioncis7/opencore/gpt/command/GptLogCommand.java
@@ -1,0 +1,41 @@
+package com.illusioncis7.opencore.gpt.command;
+
+import com.illusioncis7.opencore.gpt.GptResponseHandler;
+import com.illusioncis7.opencore.gpt.GptResponseRecord;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.UUID;
+
+public class GptLogCommand implements CommandExecutor {
+    private final GptResponseHandler handler;
+
+    public GptLogCommand(GptResponseHandler handler) {
+        this.handler = handler;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player)) {
+            sender.sendMessage("Players only.");
+            return true;
+        }
+        UUID uuid = ((Player) sender).getUniqueId();
+        List<GptResponseRecord> list = handler.getRecentResponses(uuid, 5);
+        if (list.isEmpty()) {
+            sender.sendMessage("No GPT responses found.");
+            return true;
+        }
+        DateTimeFormatter fmt = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+        for (GptResponseRecord rec : list) {
+            String time = fmt.format(rec.timestamp);
+            String prefix = rec.module != null ? "[" + rec.module + "] " : "";
+            sender.sendMessage(time + " " + prefix + rec.response);
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/illusioncis7/opencore/reputation/command/MyRepCommand.java
+++ b/src/main/java/com/illusioncis7/opencore/reputation/command/MyRepCommand.java
@@ -1,0 +1,41 @@
+package com.illusioncis7.opencore.reputation.command;
+
+import com.illusioncis7.opencore.reputation.ReputationEvent;
+import com.illusioncis7.opencore.reputation.ReputationService;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.UUID;
+
+public class MyRepCommand implements CommandExecutor {
+    private final ReputationService reputationService;
+
+    public MyRepCommand(ReputationService reputationService) {
+        this.reputationService = reputationService;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player)) {
+            sender.sendMessage("Players only.");
+            return true;
+        }
+        Player player = (Player) sender;
+        UUID uuid = player.getUniqueId();
+        int rep = reputationService.getReputation(uuid);
+        sender.sendMessage("Your reputation: " + rep);
+        List<ReputationEvent> hist = reputationService.getHistory(uuid);
+        int start = Math.max(0, hist.size() - 3);
+        DateTimeFormatter fmt = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+        for (int i = hist.size() - 1; i >= start; i--) {
+            ReputationEvent ev = hist.get(i);
+            String time = fmt.format(ev.timestamp);
+            sender.sendMessage(time + " - " + ev.reasonSummary + " (" + (ev.change >= 0 ? "+" : "") + ev.change + ")");
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/illusioncis7/opencore/reputation/command/RepInfoCommand.java
+++ b/src/main/java/com/illusioncis7/opencore/reputation/command/RepInfoCommand.java
@@ -1,0 +1,48 @@
+package com.illusioncis7.opencore.reputation.command;
+
+import com.illusioncis7.opencore.reputation.ReputationEvent;
+import com.illusioncis7.opencore.reputation.ReputationService;
+import org.bukkit.Bukkit;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.UUID;
+
+public class RepInfoCommand implements CommandExecutor {
+    private final ReputationService reputationService;
+
+    public RepInfoCommand(ReputationService reputationService) {
+        this.reputationService = reputationService;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!sender.isOp()) {
+            sender.sendMessage("Admins only.");
+            return true;
+        }
+        if (args.length < 1) {
+            sender.sendMessage("Usage: /repinfo <player>");
+            return true;
+        }
+        Player target = Bukkit.getPlayer(args[0]);
+        if (target == null) {
+            sender.sendMessage("Player not found.");
+            return true;
+        }
+        UUID uuid = target.getUniqueId();
+        int rep = reputationService.getReputation(uuid);
+        sender.sendMessage(target.getName() + " reputation: " + rep);
+        List<ReputationEvent> hist = reputationService.getHistory(uuid);
+        DateTimeFormatter fmt = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+        for (ReputationEvent ev : hist) {
+            String time = fmt.format(ev.timestamp);
+            sender.sendMessage(time + " - " + ev.reasonSummary + " (" + (ev.change >= 0 ? "+" : "") + ev.change + ")");
+        }
+        return true;
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -14,3 +14,9 @@ commands:
     description: List server rules
   rollbackconfig:
     description: Roll back a configuration change
+  myrep:
+    description: Show your reputation
+  gptlog:
+    description: Show recent GPT responses
+  repinfo:
+    description: Show reputation info for a player


### PR DESCRIPTION
## Summary
- let players inspect reputation and GPT feedback
- add `/myrep`, `/gptlog`, `/repinfo` commands
- expose latest GPT responses via `GptResponseHandler`

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844a1ed9abc8323b26fa6eafe79c25f