### PR TITLE
Enhance reputation and voting features

### DIFF
--- a/src/main/java/com/illusioncis7/opencore/OpenCore.java
+++ b/src/main/java/com/illusioncis7/opencore/OpenCore.java
@@ -79,12 +79,13 @@ public class OpenCore extends JavaPlugin {
         Objects.requireNonNull(getCommand("myrep")).setExecutor(new com.illusioncis7.opencore.reputation.command.MyRepCommand(reputationService));
         Objects.requireNonNull(getCommand("gptlog")).setExecutor(new com.illusioncis7.opencore.gpt.command.GptLogCommand(gptResponseHandler));
         Objects.requireNonNull(getCommand("repinfo")).setExecutor(new com.illusioncis7.opencore.reputation.command.RepInfoCommand(reputationService));
+        Objects.requireNonNull(getCommand("repchange")).setExecutor(new com.illusioncis7.opencore.reputation.command.RepChangeCommand(reputationService));
 
         new com.illusioncis7.opencore.reputation.ChatAnalyzerTask(database, gptService, reputationService, getLogger())
                 .runTaskTimerAsynchronously(this, 0L, 30 * 60 * 20L);
 
         getServer().getPluginManager().registerEvents(new ChatLogger(database, getLogger()), this);
-        getServer().getPluginManager().registerEvents(new PlayerJoinListener(reputationService, getLogger()), this);
+        getServer().getPluginManager().registerEvents(new PlayerJoinListener(reputationService, getLogger(), planHook), this);
         getServer().getPluginManager().registerEvents(gptResponseHandler, this);
     }
 

--- a/src/main/java/com/illusioncis7/opencore/plan/PlanHook.java
+++ b/src/main/java/com/illusioncis7/opencore/plan/PlanHook.java
@@ -55,4 +55,29 @@ public class PlanHook {
             return set;
         });
     }
+
+    /**
+     * Fetch the last session end time for a player.
+     *
+     * @param uuid Player UUID
+     * @return Instant of the last seen time or null if unavailable
+     */
+    public java.time.Instant getLastSeen(UUID uuid) {
+        if (queryService == null) return null;
+        String sql = "SELECT MAX(plan_sessions.session_end) FROM plan_sessions " +
+                "JOIN plan_users ON plan_users.id = plan_sessions.user_id " +
+                "WHERE plan_users.uuid = ?";
+        return queryService.query(sql, stmt -> {
+            stmt.setString(1, uuid.toString());
+            try (ResultSet rs = stmt.executeQuery()) {
+                if (rs.next()) {
+                    long ts = rs.getLong(1);
+                    if (ts > 0) {
+                        return java.time.Instant.ofEpochMilli(ts);
+                    }
+                }
+            }
+            return null;
+        });
+    }
 }

--- a/src/main/java/com/illusioncis7/opencore/reputation/PlayerJoinListener.java
+++ b/src/main/java/com/illusioncis7/opencore/reputation/PlayerJoinListener.java
@@ -6,14 +6,17 @@ import org.bukkit.event.player.PlayerJoinEvent;
 
 import java.util.UUID;
 import java.util.logging.Logger;
+import com.illusioncis7.opencore.plan.PlanHook;
 
 public class PlayerJoinListener implements Listener {
     private final ReputationService reputationService;
     private final Logger logger;
+    private final PlanHook planHook;
 
-    public PlayerJoinListener(ReputationService reputationService, Logger logger) {
+    public PlayerJoinListener(ReputationService reputationService, Logger logger, PlanHook planHook) {
         this.reputationService = reputationService;
         this.logger = logger;
+        this.planHook = planHook;
     }
 
     @EventHandler
@@ -21,6 +24,10 @@ public class PlayerJoinListener implements Listener {
         UUID uuid = event.getPlayer().getUniqueId();
         try {
             reputationService.registerPlayer(uuid);
+            if (planHook != null && planHook.isAvailable()) {
+                java.time.Instant last = planHook.getLastSeen(uuid);
+                reputationService.applyInactivityDecay(uuid, last);
+            }
         } catch (Exception e) {
             logger.warning("Failed to register player on join: " + e.getMessage());
         }

--- a/src/main/java/com/illusioncis7/opencore/reputation/command/RepChangeCommand.java
+++ b/src/main/java/com/illusioncis7/opencore/reputation/command/RepChangeCommand.java
@@ -1,0 +1,51 @@
+package com.illusioncis7.opencore.reputation.command;
+
+import com.illusioncis7.opencore.reputation.ReputationEvent;
+import com.illusioncis7.opencore.reputation.ReputationService;
+import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+
+import java.util.UUID;
+
+/**
+ * Admin command to inspect a specific reputation change event.
+ */
+public class RepChangeCommand implements CommandExecutor {
+    private final ReputationService reputationService;
+
+    public RepChangeCommand(ReputationService reputationService) {
+        this.reputationService = reputationService;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!sender.isOp()) {
+            sender.sendMessage("Admins only.");
+            return true;
+        }
+        if (args.length < 1) {
+            sender.sendMessage("Usage: /repchange <eventId>");
+            return true;
+        }
+        try {
+            UUID id = UUID.fromString(args[0]);
+            ReputationEvent ev = reputationService.getEvent(id);
+            if (ev == null) {
+                sender.sendMessage("Change not found.");
+                return true;
+            }
+            OfflinePlayer p = Bukkit.getOfflinePlayer(ev.playerUuid);
+            String name = p != null ? p.getName() : ev.playerUuid.toString();
+            sender.sendMessage("Player: " + name);
+            sender.sendMessage("Value: " + (ev.change >= 0 ? "+" : "") + ev.change);
+            sender.sendMessage("Reason: " + ev.reasonSummary);
+            sender.sendMessage("GPT-Kategorie: " + ev.sourceModule);
+        } catch (IllegalArgumentException e) {
+            sender.sendMessage("Invalid ID format.");
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/illusioncis7/opencore/voting/command/SuggestionsCommand.java
+++ b/src/main/java/com/illusioncis7/opencore/voting/command/SuggestionsCommand.java
@@ -27,7 +27,12 @@ public class SuggestionsCommand implements CommandExecutor {
             VoteWeights w = votingService.getVoteWeights(s.id);
             int remaining = Math.max(0, w.requiredWeight - w.yesWeight);
             String title = (s.description != null && !s.description.isEmpty()) ? s.description : s.text;
-            sender.sendMessage("#" + s.id + " - " + title + " [" + w.yesWeight + "/" + w.requiredWeight + " yes] " + remaining + " votes needed");
+            String progress = w.yesWeight + "/" + w.requiredWeight + " yes";
+            if (remaining > 0) {
+                sender.sendMessage("#" + s.id + " - " + title + " [" + progress + "] " + remaining + " votes needed");
+            } else {
+                sender.sendMessage("#" + s.id + " - " + title + " [" + progress + "] quorum reached");
+            }
         }
         return true;
     }

--- a/src/main/java/com/illusioncis7/opencore/voting/command/VoteCommand.java
+++ b/src/main/java/com/illusioncis7/opencore/voting/command/VoteCommand.java
@@ -34,7 +34,13 @@ public class VoteCommand implements CommandExecutor {
                 return true;
             }
             if (votingService.isSuggestionOpen(id)) {
-                sender.sendMessage("Vote registered.");
+                com.illusioncis7.opencore.voting.VotingService.VoteWeights w = votingService.getVoteWeights(id);
+                int remaining = Math.max(0, w.requiredWeight - w.yesWeight);
+                if (remaining > 0) {
+                    sender.sendMessage("Noch " + remaining + " Stimmen nötig.");
+                } else {
+                    sender.sendMessage("Quorum erreicht – Voting endet");
+                }
             } else {
                 sender.sendMessage("Voting concluded.");
             }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -20,3 +20,5 @@ commands:
     description: Show recent GPT responses
   repinfo:
     description: Show reputation info for a player
+  repchange:
+    description: Show details for a reputation change event


### PR DESCRIPTION
## Summary
- add inactivity-based reputation decay and an admin setter
- expose reputation events through new `/repchange` command
- display quorum progress for suggestions
- notify players how many votes are still required
- hook into Plan API to determine last seen timestamps

## Testing
- `mvn -q test` *(fails: PluginResolutionException)*

------
https://chatgpt.com/codex/tasks/task_e_6844a4c6362c832383a745dfa6512444