### PR TITLE
Add admin tools and webhook

### DIFF
--- a/src/main/java/com/illusioncis7/opencore/OpenCore.java
+++ b/src/main/java/com/illusioncis7/opencore/OpenCore.java
@@ -15,6 +15,8 @@ import com.illusioncis7.opencore.voting.command.VoteCommand;
 import com.illusioncis7.opencore.rules.RuleService;
 import com.illusioncis7.opencore.rules.command.RulesCommand;
 import com.illusioncis7.opencore.config.command.RollbackConfigCommand;
+import com.illusioncis7.opencore.config.command.ConfigListCommand;
+import com.illusioncis7.opencore.admin.StatusCommand;
 import com.illusioncis7.opencore.plan.PlanHook;
 import java.io.File;
 import java.util.Objects;
@@ -80,6 +82,8 @@ public class OpenCore extends JavaPlugin {
         Objects.requireNonNull(getCommand("gptlog")).setExecutor(new com.illusioncis7.opencore.gpt.command.GptLogCommand(gptResponseHandler));
         Objects.requireNonNull(getCommand("repinfo")).setExecutor(new com.illusioncis7.opencore.reputation.command.RepInfoCommand(reputationService));
         Objects.requireNonNull(getCommand("repchange")).setExecutor(new com.illusioncis7.opencore.reputation.command.RepChangeCommand(reputationService));
+        Objects.requireNonNull(getCommand("status")).setExecutor(new com.illusioncis7.opencore.admin.StatusCommand(gptQueueManager, votingService, database, gptService));
+        Objects.requireNonNull(getCommand("configlist")).setExecutor(new com.illusioncis7.opencore.config.command.ConfigListCommand(configService));
 
         new com.illusioncis7.opencore.reputation.ChatAnalyzerTask(database, gptService, reputationService, getLogger())
                 .runTaskTimerAsynchronously(this, 0L, 30 * 60 * 20L);

--- a/src/main/java/com/illusioncis7/opencore/admin/StatusCommand.java
+++ b/src/main/java/com/illusioncis7/opencore/admin/StatusCommand.java
@@ -1,0 +1,37 @@
+package com.illusioncis7.opencore.admin;
+
+import com.illusioncis7.opencore.database.Database;
+import com.illusioncis7.opencore.gpt.GptQueueManager;
+import com.illusioncis7.opencore.gpt.GptService;
+import com.illusioncis7.opencore.voting.VotingService;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+
+public class StatusCommand implements CommandExecutor {
+    private final GptQueueManager queueManager;
+    private final VotingService votingService;
+    private final Database database;
+    private final GptService gptService;
+
+    public StatusCommand(GptQueueManager queueManager, VotingService votingService,
+                         Database database, GptService gptService) {
+        this.queueManager = queueManager;
+        this.votingService = votingService;
+        this.database = database;
+        this.gptService = gptService;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        int queue = queueManager.getQueueSize();
+        int open = votingService.getOpenSuggestions().size();
+        long ping = database.ping();
+        long last = gptService.getLastResponseDuration();
+        sender.sendMessage("GPT queue: " + queue);
+        sender.sendMessage("Open suggestions: " + open);
+        sender.sendMessage("DB ping: " + (ping >= 0 ? ping + " ms" : "n/a"));
+        sender.sendMessage("Last GPT response: " + (last >= 0 ? last + " ms" : "n/a"));
+        return true;
+    }
+}

--- a/src/main/java/com/illusioncis7/opencore/config/ConfigParameter.java
+++ b/src/main/java/com/illusioncis7/opencore/config/ConfigParameter.java
@@ -11,6 +11,7 @@ public class ConfigParameter {
     private boolean editable;
     private String impactCategory;
     private int impactRating = 5;
+    private String currentValue;
 
     public ConfigParameter() {}
 
@@ -97,6 +98,14 @@ public class ConfigParameter {
 
     public void setImpactRating(int impactRating) {
         this.impactRating = impactRating;
+    }
+
+    public String getCurrentValue() {
+        return currentValue;
+    }
+
+    public void setCurrentValue(String currentValue) {
+        this.currentValue = currentValue;
     }
 
     /**

--- a/src/main/java/com/illusioncis7/opencore/config/ConfigService.java
+++ b/src/main/java/com/illusioncis7/opencore/config/ConfigService.java
@@ -268,5 +268,34 @@ public class ConfigService {
         }
         return false;
     }
+
+    /**
+     * Fetch all configuration parameters with their current value.
+     */
+    public java.util.List<ConfigParameter> listParameters() {
+        java.util.List<ConfigParameter> list = new java.util.ArrayList<>();
+        if (database.getConnection() == null) return list;
+        String sql = "SELECT id, path, parameter_path, editable, impact_rating FROM config_params";
+        try (Connection conn = database.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql);
+             ResultSet rs = ps.executeQuery()) {
+            while (rs.next()) {
+                ConfigParameter p = new ConfigParameter();
+                p.setId(rs.getInt(1));
+                String path = rs.getString(2);
+                String param = rs.getString(3);
+                p.setPath(path);
+                p.setParameterPath(param);
+                p.setEditable(rs.getBoolean(4));
+                p.setImpactRating(rs.getInt(5));
+                Object val = loadValue(new File(path), param);
+                p.setCurrentValue(val != null ? val.toString() : null);
+                list.add(p);
+            }
+        } catch (SQLException e) {
+            plugin.getLogger().warning("Failed to load config parameters: " + e.getMessage());
+        }
+        return list;
+    }
 }
 

--- a/src/main/java/com/illusioncis7/opencore/config/command/ConfigListCommand.java
+++ b/src/main/java/com/illusioncis7/opencore/config/command/ConfigListCommand.java
@@ -1,0 +1,32 @@
+package com.illusioncis7.opencore.config.command;
+
+import com.illusioncis7.opencore.config.ConfigParameter;
+import com.illusioncis7.opencore.config.ConfigService;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+
+import java.util.List;
+
+public class ConfigListCommand implements CommandExecutor {
+    private final ConfigService configService;
+
+    public ConfigListCommand(ConfigService configService) {
+        this.configService = configService;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        List<ConfigParameter> list = configService.listParameters();
+        if (list.isEmpty()) {
+            sender.sendMessage("No parameters found.");
+            return true;
+        }
+        for (ConfigParameter p : list) {
+            String value = p.getCurrentValue() != null ? p.getCurrentValue() : "null";
+            sender.sendMessage("#" + p.getId() + " " + p.getParameterPath() + " = " + value +
+                    " editable=" + p.isEditable() + " impact=" + p.getImpactRating());
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/illusioncis7/opencore/database/Database.java
+++ b/src/main/java/com/illusioncis7/opencore/database/Database.java
@@ -193,6 +193,21 @@ public class Database {
         return null;
     }
 
+    /**
+     * Measure database ping time in milliseconds.
+     */
+    public long ping() {
+        if (connection == null) return -1;
+        long start = System.currentTimeMillis();
+        try (PreparedStatement ps = connection.prepareStatement("SELECT 1")) {
+            ps.execute();
+        } catch (SQLException e) {
+            plugin.getLogger().warning("DB ping failed: " + e.getMessage());
+            return -1;
+        }
+        return System.currentTimeMillis() - start;
+    }
+
     public void disconnect() {
         if (connection != null) {
             try {

--- a/src/main/java/com/illusioncis7/opencore/gpt/GptQueueManager.java
+++ b/src/main/java/com/illusioncis7/opencore/gpt/GptQueueManager.java
@@ -23,6 +23,13 @@ public class GptQueueManager {
     private final Logger logger;
     private final int maxQueueSize;
 
+    /**
+     * Get current queue size.
+     */
+    public int getQueueSize() {
+        return queue.size();
+    }
+
     public GptQueueManager(JavaPlugin plugin, GptService gptService, GptResponseHandler responseHandler) {
         this(plugin, gptService, responseHandler, 100);
     }

--- a/src/main/java/com/illusioncis7/opencore/voting/GptSuggestionClassifier.java
+++ b/src/main/java/com/illusioncis7/opencore/voting/GptSuggestionClassifier.java
@@ -33,7 +33,8 @@ public class GptSuggestionClassifier {
      * @param onConfig     callback executed if the suggestion is classified as CONFIG_CHANGE
      * @param onRule       callback executed if the suggestion is classified as RULE_CHANGE
      */
-    public void classify(int suggestionId, String text, Runnable onConfig, Runnable onRule) {
+    public void classify(int suggestionId, String text, Runnable onConfig, Runnable onRule,
+                         java.util.function.Consumer<SuggestionType> after) {
         gptService.submitTemplate("suggest_classify", text, null, response -> {
             if (response == null || response.isEmpty()) {
                 handleFailure(suggestionId, "Empty GPT response");
@@ -53,6 +54,9 @@ public class GptSuggestionClassifier {
                     onConfig.run();
                 } else if (type == SuggestionType.RULE_CHANGE && onRule != null) {
                     onRule.run();
+                }
+                if (after != null) {
+                    after.accept(type);
                 }
             } catch (Exception e) {
                 handleFailure(suggestionId, "Parse error: " + e.getMessage());

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,2 +1,3 @@
 # Allgemeine Plugin-Konfiguration
 config-version: 1
+discord-webhook-url: ""

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -22,3 +22,7 @@ commands:
     description: Show reputation info for a player
   repchange:
     description: Show details for a reputation change event
+  status:
+    description: Show plugin status
+  configlist:
+    description: List configurable parameters

--- a/src/test/java/com/illusioncis7/opencore/voting/VotingServiceTest.java
+++ b/src/test/java/com/illusioncis7/opencore/voting/VotingServiceTest.java
@@ -36,13 +36,16 @@ public class VotingServiceTest {
     private RuleService ruleService;
     @Mock
     private ReputationService reputationService;
+    @Mock
+    private com.illusioncis7.opencore.plan.PlanHook planHook;
 
     private VotingService service;
 
     @BeforeEach
     public void setup() {
         when(plugin.getLogger()).thenReturn(Logger.getLogger("test"));
-        service = new VotingService(plugin, database, gptService, configService, ruleService, reputationService);
+        when(plugin.getConfig()).thenReturn(new org.bukkit.configuration.file.YamlConfiguration());
+        service = new VotingService(plugin, database, gptService, configService, ruleService, reputationService, planHook);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- add `/status` admin command for health info
- add `/configlist` admin command to list parameters
- expose GPT queue size and last response duration
- enable optional Discord webhook for new suggestions
- include DB ping utility
- update tests for new constructor

## Testing
- `mvn -q test` *(fails: Plugin resolution from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_6844a6145b888323a11a0d91ad2c512c