### PR TITLE
Improve voting integrity features

### DIFF
--- a/src/main/java/com/illusioncis7/opencore/OpenCore.java
+++ b/src/main/java/com/illusioncis7/opencore/OpenCore.java
@@ -12,6 +12,7 @@ import com.illusioncis7.opencore.voting.VotingService;
 import com.illusioncis7.opencore.voting.command.SuggestCommand;
 import com.illusioncis7.opencore.voting.command.SuggestionsCommand;
 import com.illusioncis7.opencore.voting.command.VoteCommand;
+import com.illusioncis7.opencore.voting.command.VoteStatusCommand;
 import com.illusioncis7.opencore.rules.RuleService;
 import com.illusioncis7.opencore.rules.command.RulesCommand;
 import com.illusioncis7.opencore.config.command.RollbackConfigCommand;
@@ -22,6 +23,7 @@ import java.io.File;
 import java.util.Objects;
 
 import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.scheduler.BukkitRunnable;
 
 public class OpenCore extends JavaPlugin {
 
@@ -84,9 +86,17 @@ public class OpenCore extends JavaPlugin {
         Objects.requireNonNull(getCommand("repchange")).setExecutor(new com.illusioncis7.opencore.reputation.command.RepChangeCommand(reputationService));
         Objects.requireNonNull(getCommand("status")).setExecutor(new com.illusioncis7.opencore.admin.StatusCommand(gptQueueManager, votingService, database, gptService));
         Objects.requireNonNull(getCommand("configlist")).setExecutor(new com.illusioncis7.opencore.config.command.ConfigListCommand(configService));
+        Objects.requireNonNull(getCommand("votestatus")).setExecutor(new com.illusioncis7.opencore.voting.command.VoteStatusCommand(votingService));
 
         new com.illusioncis7.opencore.reputation.ChatAnalyzerTask(database, gptService, reputationService, getLogger())
                 .runTaskTimerAsynchronously(this, 0L, 30 * 60 * 20L);
+
+        new BukkitRunnable() {
+            @Override
+            public void run() {
+                votingService.checkOpenSuggestions();
+            }
+        }.runTaskTimer(this, 0L, 30 * 60 * 20L);
 
         getServer().getPluginManager().registerEvents(new ChatLogger(database, getLogger()), this);
         getServer().getPluginManager().registerEvents(new PlayerJoinListener(reputationService, getLogger(), planHook), this);

--- a/src/main/java/com/illusioncis7/opencore/voting/command/SuggestCommand.java
+++ b/src/main/java/com/illusioncis7/opencore/voting/command/SuggestCommand.java
@@ -30,6 +30,10 @@ public class SuggestCommand implements CommandExecutor {
             OpenCore.getInstance().getLogger().warning("Rejected short suggestion from " + sender.getName());
             return true;
         }
+        if (votingService.isSimilarSuggestionRecent(text, java.time.Duration.ofHours(24), 10)) {
+            sender.sendMessage("Ähnlicher Vorschlag existiert bereits.");
+            return true;
+        }
         int id = votingService.submitSuggestion(((Player) sender).getUniqueId(), text);
         if (id == -1) {
             sender.sendMessage("Failed to submit suggestion.");

--- a/src/main/java/com/illusioncis7/opencore/voting/command/VoteCommand.java
+++ b/src/main/java/com/illusioncis7/opencore/voting/command/VoteCommand.java
@@ -27,7 +27,12 @@ public class VoteCommand implements CommandExecutor {
         try {
             int id = Integer.parseInt(args[0]);
             boolean yes = args[1].equalsIgnoreCase("yes") || args[1].equalsIgnoreCase("y");
-            boolean success = votingService.castVote(((Player) sender).getUniqueId(), id, yes);
+            Player player = (Player) sender;
+            if (votingService.hasPlayerVoted(player.getUniqueId(), id)) {
+                sender.sendMessage("Du hast bereits abgestimmt.");
+                return true;
+            }
+            boolean success = votingService.castVote(player.getUniqueId(), id, yes);
             if (!success) {
                 sender.sendMessage("Unknown or closed suggestion.");
                 OpenCore.getInstance().getLogger().warning("Invalid vote from " + sender.getName() + " for " + id);

--- a/src/main/java/com/illusioncis7/opencore/voting/command/VoteStatusCommand.java
+++ b/src/main/java/com/illusioncis7/opencore/voting/command/VoteStatusCommand.java
@@ -1,0 +1,36 @@
+package com.illusioncis7.opencore.voting.command;
+
+import com.illusioncis7.opencore.voting.Suggestion;
+import com.illusioncis7.opencore.voting.VotingService;
+import com.illusioncis7.opencore.voting.VotingService.VoteWeights;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+
+import java.util.List;
+
+public class VoteStatusCommand implements CommandExecutor {
+    private final VotingService votingService;
+
+    public VoteStatusCommand(VotingService votingService) {
+        this.votingService = votingService;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        List<Suggestion> list = votingService.getClosedSuggestions();
+        if (list.isEmpty()) {
+            sender.sendMessage("Keine abgeschlossenen Vorschläge.");
+            return true;
+        }
+        for (Suggestion s : list) {
+            VoteWeights w = votingService.getVoteWeights(s.id);
+            boolean accepted = w.yesWeight > w.noWeight && w.yesWeight >= w.requiredWeight;
+            String title = (s.description != null && !s.description.isEmpty()) ? s.description : s.text;
+            String result = accepted ? "angenommen" : "abgelehnt";
+            String change = s.newValue != null ? s.newValue : "";
+            sender.sendMessage("#" + s.id + " - " + title + " -> " + result + (accepted && !change.isEmpty() ? ": " + change : ""));
+        }
+        return true;
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -26,3 +26,5 @@ commands:
     description: Show plugin status
   configlist:
     description: List configurable parameters
+  votestatus:
+    description: Show closed vote results


### PR DESCRIPTION
## Summary
- schedule periodic voting checks and enforce quorum/expiry
- avoid duplicate suggestions via Levenshtein check
- prevent duplicate votes by the same player
- expose closed vote results with `/votestatus`
- register new command and scheduler in plugin entry

## Testing
- `mvn -q test` *(fails: PluginResolutionException – network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6844ab792aa08323a511f717fe79f205