### PR TITLE
Improve rule and config structure

### DIFF
--- a/src/main/java/com/illusioncis7/opencore/OpenCore.java
+++ b/src/main/java/com/illusioncis7/opencore/OpenCore.java
@@ -15,6 +15,7 @@ import com.illusioncis7.opencore.voting.command.VoteCommand;
 import com.illusioncis7.opencore.voting.command.VoteStatusCommand;
 import com.illusioncis7.opencore.rules.RuleService;
 import com.illusioncis7.opencore.rules.command.RulesCommand;
+import com.illusioncis7.opencore.rules.command.EditRuleCommand;
 import com.illusioncis7.opencore.config.command.RollbackConfigCommand;
 import com.illusioncis7.opencore.config.command.ConfigListCommand;
 import com.illusioncis7.opencore.admin.StatusCommand;
@@ -79,6 +80,7 @@ public class OpenCore extends JavaPlugin {
         Objects.requireNonNull(getCommand("suggestions")).setExecutor(new SuggestionsCommand(votingService));
         Objects.requireNonNull(getCommand("vote")).setExecutor(new VoteCommand(votingService));
         Objects.requireNonNull(getCommand("rules")).setExecutor(new RulesCommand(ruleService));
+        Objects.requireNonNull(getCommand("editrule")).setExecutor(new EditRuleCommand(ruleService));
         Objects.requireNonNull(getCommand("rollbackconfig")).setExecutor(new RollbackConfigCommand(configService));
         Objects.requireNonNull(getCommand("myrep")).setExecutor(new com.illusioncis7.opencore.reputation.command.MyRepCommand(reputationService));
         Objects.requireNonNull(getCommand("gptlog")).setExecutor(new com.illusioncis7.opencore.gpt.command.GptLogCommand(gptResponseHandler));

--- a/src/main/java/com/illusioncis7/opencore/config/ConfigParameter.java
+++ b/src/main/java/com/illusioncis7/opencore/config/ConfigParameter.java
@@ -1,5 +1,7 @@
 package com.illusioncis7.opencore.config;
 
+import com.illusioncis7.opencore.config.ConfigType;
+
 public class ConfigParameter {
     private int id;
     private String path;
@@ -12,6 +14,7 @@ public class ConfigParameter {
     private String impactCategory;
     private int impactRating = 5;
     private String currentValue;
+    private ConfigType valueType = ConfigType.STRING;
 
     public ConfigParameter() {}
 
@@ -108,6 +111,14 @@ public class ConfigParameter {
         this.currentValue = currentValue;
     }
 
+    public ConfigType getValueType() {
+        return valueType;
+    }
+
+    public void setValueType(ConfigType valueType) {
+        this.valueType = valueType;
+    }
+
     /**
      * Validate the provided value against this parameter's constraints.
      *
@@ -118,16 +129,20 @@ public class ConfigParameter {
         if (value == null) {
             return false;
         }
-        try {
-            int v;
-            if (value instanceof Number) {
-                v = ((Number) value).intValue();
-            } else {
-                v = Integer.parseInt(value.toString());
-            }
-            return v >= minValue && v <= maxValue;
-        } catch (NumberFormatException e) {
-            return false;
+        switch (valueType) {
+            case BOOLEAN:
+                return "true".equalsIgnoreCase(value.toString()) || "false".equalsIgnoreCase(value.toString());
+            case INTEGER:
+                try {
+                    int v = Integer.parseInt(value.toString());
+                    return v >= minValue && v <= maxValue;
+                } catch (NumberFormatException e) {
+                    return false;
+                }
+            case LIST:
+            case STRING:
+            default:
+                return true;
         }
     }
 
@@ -141,7 +156,11 @@ public class ConfigParameter {
         }
         if (!isValid(value)) {
             if (sb.length() > 0) sb.append("; ");
-            sb.append("Value outside allowed range [").append(minValue).append("-").append(maxValue).append("]");
+            if (valueType == ConfigType.INTEGER) {
+                sb.append("Value outside allowed range [").append(minValue).append("-").append(maxValue).append("]");
+            } else {
+                sb.append("Invalid value for type ").append(valueType);
+            }
         }
         return sb.toString();
     }

--- a/src/main/java/com/illusioncis7/opencore/config/ConfigType.java
+++ b/src/main/java/com/illusioncis7/opencore/config/ConfigType.java
@@ -1,0 +1,11 @@
+package com.illusioncis7.opencore.config;
+
+/**
+ * Allowed data types for configurable parameters.
+ */
+public enum ConfigType {
+    BOOLEAN,
+    INTEGER,
+    STRING,
+    LIST
+}

--- a/src/main/java/com/illusioncis7/opencore/database/Database.java
+++ b/src/main/java/com/illusioncis7/opencore/database/Database.java
@@ -70,6 +70,7 @@ public class Database {
                     "impact_category VARCHAR(50)," +
                     "impact_rating INT DEFAULT 5," +
                     "description TEXT," +
+                    "value_type VARCHAR(20) DEFAULT 'STRING'," +
                     "UNIQUE KEY path_param (path, parameter_path)" +
                     ")";
             stmt.executeUpdate(cfgSql);
@@ -145,7 +146,8 @@ public class Database {
 
             String rulesSql = "CREATE TABLE IF NOT EXISTS server_rules (" +
                     "id INT AUTO_INCREMENT PRIMARY KEY," +
-                    "rule_text TEXT NOT NULL" +
+                    "rule_text TEXT NOT NULL," +
+                    "category VARCHAR(50)" +
                     ")";
             stmt.executeUpdate(rulesSql);
 

--- a/src/main/java/com/illusioncis7/opencore/rules/Rule.java
+++ b/src/main/java/com/illusioncis7/opencore/rules/Rule.java
@@ -3,9 +3,12 @@ package com.illusioncis7.opencore.rules;
 public class Rule {
     public final int id;
     public final String text;
+    /** Category of the rule such as Verhalten, Gameplay or Technik. */
+    public final String category;
 
-    public Rule(int id, String text) {
+    public Rule(int id, String text, String category) {
         this.id = id;
         this.text = text;
+        this.category = category;
     }
 }

--- a/src/main/java/com/illusioncis7/opencore/rules/RuleService.java
+++ b/src/main/java/com/illusioncis7/opencore/rules/RuleService.java
@@ -24,12 +24,12 @@ public class RuleService {
     public List<Rule> getRules() {
         List<Rule> list = new ArrayList<>();
         if (database.getConnection() == null) return list;
-        String sql = "SELECT id, rule_text FROM server_rules ORDER BY id";
+        String sql = "SELECT id, rule_text, category FROM server_rules ORDER BY id";
         try (Connection conn = database.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql);
              ResultSet rs = ps.executeQuery()) {
             while (rs.next()) {
-                list.add(new Rule(rs.getInt(1), rs.getString(2)));
+                list.add(new Rule(rs.getInt(1), rs.getString(2), rs.getString(3))); 
             }
         } catch (SQLException e) {
             logger.warning("Failed to load rules: " + e.getMessage());
@@ -39,13 +39,13 @@ public class RuleService {
 
     public Rule getRule(int id) {
         if (database.getConnection() == null) return null;
-        String sql = "SELECT id, rule_text FROM server_rules WHERE id = ?";
+        String sql = "SELECT id, rule_text, category FROM server_rules WHERE id = ?";
         try (Connection conn = database.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql)) {
             ps.setInt(1, id);
             try (ResultSet rs = ps.executeQuery()) {
                 if (rs.next()) {
-                    return new Rule(rs.getInt(1), rs.getString(2));
+                    return new Rule(rs.getInt(1), rs.getString(2), rs.getString(3));
                 }
             }
         } catch (SQLException e) {

--- a/src/main/java/com/illusioncis7/opencore/rules/command/EditRuleCommand.java
+++ b/src/main/java/com/illusioncis7/opencore/rules/command/EditRuleCommand.java
@@ -1,0 +1,42 @@
+package com.illusioncis7.opencore.rules.command;
+
+import com.illusioncis7.opencore.rules.RuleService;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import java.util.Arrays;
+import java.util.UUID;
+
+/** Command for editing rules directly. */
+public class EditRuleCommand implements CommandExecutor {
+    private final RuleService ruleService;
+
+    public EditRuleCommand(RuleService ruleService) {
+        this.ruleService = ruleService;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (args.length < 2) {
+            sender.sendMessage("Usage: /editrule <id> <new text>");
+            return true;
+        }
+        int id;
+        try {
+            id = Integer.parseInt(args[0]);
+        } catch (NumberFormatException e) {
+            sender.sendMessage("Invalid id.");
+            return true;
+        }
+        String newText = String.join(" ", Arrays.copyOfRange(args, 1, args.length));
+        UUID changer = sender instanceof Player ? ((Player) sender).getUniqueId() : null;
+        if (ruleService.updateRule(id, newText, changer, null)) {
+            sender.sendMessage("Rule updated.");
+        } else {
+            sender.sendMessage("Failed to update rule.");
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/illusioncis7/opencore/rules/command/RulesCommand.java
+++ b/src/main/java/com/illusioncis7/opencore/rules/command/RulesCommand.java
@@ -24,7 +24,7 @@ public class RulesCommand implements CommandExecutor {
                 if (r == null) {
                     sender.sendMessage("Rule not found.");
                 } else {
-                    sender.sendMessage("#" + r.id + ": " + r.text);
+                    sender.sendMessage("#" + r.id + " [" + r.category + "]: " + r.text);
                 }
             } catch (NumberFormatException e) {
                 sender.sendMessage("Invalid id.");
@@ -38,7 +38,7 @@ public class RulesCommand implements CommandExecutor {
             return true;
         }
         for (Rule r : rules) {
-            sender.sendMessage("#" + r.id + ": " + r.text);
+            sender.sendMessage("#" + r.id + " [" + r.category + "]: " + r.text);
         }
         return true;
     }

--- a/src/main/java/com/illusioncis7/opencore/voting/VotingService.java
+++ b/src/main/java/com/illusioncis7/opencore/voting/VotingService.java
@@ -99,6 +99,11 @@ public class VotingService {
     }
 
     private void mapConfigChange(int suggestionId, UUID player, String text) {
+        if (countParameterChanges(text) > 5) {
+            storeMappingError(suggestionId, "Too many parameter changes (>5)");
+            markClosed(suggestionId);
+            return;
+        }
         gptService.submitTemplate("suggest_map", text, player, response -> {
             if (response == null) {
                 logger.warning("GPT mapping failed for suggestion: " + text);
@@ -441,6 +446,16 @@ public class VotingService {
             curr = tmp;
         }
         return prev[b.length()];
+    }
+
+    private int countParameterChanges(String text) {
+        if (text == null || text.isEmpty()) return 0;
+        String[] parts = text.split("[;\n]");
+        int c = 0;
+        for (String p : parts) {
+            if (!p.trim().isEmpty()) c++;
+        }
+        return c;
     }
 
     public void checkOpenSuggestions() {

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -28,3 +28,5 @@ commands:
     description: List configurable parameters
   votestatus:
     description: Show closed vote results
+  editrule:
+    description: Edit an existing rule


### PR DESCRIPTION
## Summary
- add `ConfigType` enum and use for validation
- support rule categories in `Rule` and `RuleService`
- implement `/editrule` command
- add validation helpers and default type when scanning configs
- show rule categories in `/rules`
- limit suggestions with more than five parameter changes
- extend database tables for new fields

## Testing
- `mvn -q test` *(fails: PluginResolutionException due to network)*

------
https://chatgpt.com/codex/tasks/task_e_6844b0952a60832387492d4432b86c2e