### PR TITLE
Implement rate limiting and history features

### DIFF
--- a/src/main/java/com/illusioncis7/opencore/OpenCore.java
+++ b/src/main/java/com/illusioncis7/opencore/OpenCore.java
@@ -100,6 +100,10 @@ public class OpenCore extends JavaPlugin {
         Objects.requireNonNull(getCommand("editrule")).setExecutor(editRuleCmd);
         getCommand("editrule").setTabCompleter(editRuleCmd);
 
+        com.illusioncis7.opencore.rules.command.RuleHistoryCommand ruleHistCmd = new com.illusioncis7.opencore.rules.command.RuleHistoryCommand(ruleService);
+        Objects.requireNonNull(getCommand("rulehistory")).setExecutor(ruleHistCmd);
+        getCommand("rulehistory").setTabCompleter(ruleHistCmd);
+
         RollbackConfigCommand rollCmd = new RollbackConfigCommand(configService);
         Objects.requireNonNull(getCommand("rollbackconfig")).setExecutor(rollCmd);
         getCommand("rollbackconfig").setTabCompleter(rollCmd);
@@ -150,8 +154,9 @@ public class OpenCore extends JavaPlugin {
                 org.bukkit.configuration.file.YamlConfiguration.loadConfiguration(
                         new File(getDataFolder(), "api.yml"));
         int port = apiCfg.getInt("port", 0);
+        boolean exposeRep = apiCfg.getBoolean("expose-reputations", true);
         try {
-            apiServer = new com.illusioncis7.opencore.api.ApiServer(port, votingService,
+            apiServer = new com.illusioncis7.opencore.api.ApiServer(port, exposeRep, votingService,
                     reputationService, ruleService, getLogger());
         } catch (Exception e) {
             getLogger().warning("Failed to start API server: " + e.getMessage());

--- a/src/main/java/com/illusioncis7/opencore/api/ApiServer.java
+++ b/src/main/java/com/illusioncis7/opencore/api/ApiServer.java
@@ -28,13 +28,15 @@ public class ApiServer {
     private final RuleService ruleService;
     private final Logger logger;
     private HttpServer server;
+    private final boolean exposeReputations;
 
-    public ApiServer(int port, VotingService votingService, ReputationService reputationService,
+    public ApiServer(int port, boolean exposeReputations, VotingService votingService, ReputationService reputationService,
                      RuleService ruleService, Logger logger) throws IOException {
         this.votingService = votingService;
         this.reputationService = reputationService;
         this.ruleService = ruleService;
         this.logger = logger;
+        this.exposeReputations = exposeReputations;
         if (port > 0) {
             server = HttpServer.create(new InetSocketAddress(port), 0);
             registerContexts();
@@ -48,7 +50,9 @@ public class ApiServer {
     private void registerContexts() {
         server.createContext("/api/suggestions", exchange -> handle(exchange, this::writeSuggestions));
         server.createContext("/api/rules", exchange -> handle(exchange, this::writeRules));
-        server.createContext("/api/reputations", exchange -> handle(exchange, this::writeReputations));
+        if (exposeReputations) {
+            server.createContext("/api/reputations", exchange -> handle(exchange, this::writeReputations));
+        }
     }
 
     private interface JsonWriter {

--- a/src/main/java/com/illusioncis7/opencore/reputation/command/MyRepCommand.java
+++ b/src/main/java/com/illusioncis7/opencore/reputation/command/MyRepCommand.java
@@ -36,7 +36,7 @@ public class MyRepCommand implements TabExecutor {
         for (int i = hist.size() - 1; i >= start; i--) {
             ReputationEvent ev = hist.get(i);
             String time = fmt.format(ev.timestamp);
-            sender.sendMessage(time + " - " + ev.reasonSummary + " (" + (ev.change >= 0 ? "+" : "") + ev.change + ")");
+            sender.sendMessage(time + " - " + ev.reasonSummary + " [" + ev.sourceModule + "] (" + (ev.change >= 0 ? "+" : "") + ev.change + ")");
         }
         return true;
     }

--- a/src/main/java/com/illusioncis7/opencore/rules/RuleChange.java
+++ b/src/main/java/com/illusioncis7/opencore/rules/RuleChange.java
@@ -1,0 +1,25 @@
+package com.illusioncis7.opencore.rules;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public class RuleChange {
+    public final int id;
+    public final int ruleId;
+    public final String oldText;
+    public final String newText;
+    public final Instant changedAt;
+    public final UUID changedBy;
+    public final Integer suggestionId;
+
+    public RuleChange(int id, int ruleId, String oldText, String newText,
+                      Instant changedAt, UUID changedBy, Integer suggestionId) {
+        this.id = id;
+        this.ruleId = ruleId;
+        this.oldText = oldText;
+        this.newText = newText;
+        this.changedAt = changedAt;
+        this.changedBy = changedBy;
+        this.suggestionId = suggestionId;
+    }
+}

--- a/src/main/java/com/illusioncis7/opencore/rules/command/RuleHistoryCommand.java
+++ b/src/main/java/com/illusioncis7/opencore/rules/command/RuleHistoryCommand.java
@@ -1,0 +1,83 @@
+package com.illusioncis7.opencore.rules.command;
+
+import com.illusioncis7.opencore.rules.RuleChange;
+import com.illusioncis7.opencore.rules.RuleService;
+import org.bukkit.Bukkit;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabExecutor;
+
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class RuleHistoryCommand implements TabExecutor {
+    private final RuleService ruleService;
+
+    public RuleHistoryCommand(RuleService ruleService) {
+        this.ruleService = ruleService;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (args.length < 1) {
+            sender.sendMessage("Usage: /rulehistory <id> [page]");
+            return true;
+        }
+        int id;
+        try {
+            id = Integer.parseInt(args[0]);
+        } catch (NumberFormatException e) {
+            sender.sendMessage("Invalid id.");
+            return true;
+        }
+        int page = 1;
+        if (args.length >= 2) {
+            try { page = Integer.parseInt(args[1]); } catch (NumberFormatException ignore) {}
+        }
+        List<RuleChange> hist = ruleService.getHistory(id);
+        if (hist.isEmpty()) {
+            sender.sendMessage("No history found.");
+            return true;
+        }
+        int pages = (hist.size() + 4) / 5;
+        page = Math.max(1, Math.min(page, pages));
+        int start = (page - 1) * 5;
+        int end = Math.min(start + 5, hist.size());
+        DateTimeFormatter fmt = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+        for (int i = start; i < end; i++) {
+            RuleChange rc = hist.get(i);
+            String time = fmt.format(rc.changedAt);
+            String changer = rc.changedBy != null ? Bukkit.getOfflinePlayer(rc.changedBy).getName() : "system";
+            sender.sendMessage(time + " by " + changer + ": " + rc.newText);
+        }
+        sender.sendMessage("Page " + page + "/" + pages);
+        return true;
+    }
+
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+        if (args.length == 1) {
+            List<com.illusioncis7.opencore.rules.Rule> rules = ruleService.getRules();
+            List<String> ids = new ArrayList<>();
+            for (com.illusioncis7.opencore.rules.Rule r : rules) {
+                ids.add(String.valueOf(r.id));
+            }
+            return ids;
+        } else if (args.length == 2) {
+            try {
+                int id = Integer.parseInt(args[0]);
+                List<RuleChange> hist = ruleService.getHistory(id);
+                int pages = (hist.size() + 4) / 5;
+                List<String> result = new ArrayList<>();
+                for (int i = 1; i <= pages; i++) {
+                    result.add(String.valueOf(i));
+                }
+                return result;
+            } catch (NumberFormatException ignore) {
+            }
+        }
+        return Collections.emptyList();
+    }
+}

--- a/src/main/java/com/illusioncis7/opencore/voting/command/SuggestCommand.java
+++ b/src/main/java/com/illusioncis7/opencore/voting/command/SuggestCommand.java
@@ -8,9 +8,14 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.time.Instant;
+import java.time.Duration;
 
 public class SuggestCommand implements TabExecutor {
     private final VotingService votingService;
+    private final Map<java.util.UUID, Instant> lastSubmission = new HashMap<>();
 
     public SuggestCommand(VotingService votingService) {
         this.votingService = votingService;
@@ -20,6 +25,15 @@ public class SuggestCommand implements TabExecutor {
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
         if (!(sender instanceof Player)) {
             sender.sendMessage("Players only.");
+            return true;
+        }
+        Player player = (Player) sender;
+        java.util.UUID uuid = player.getUniqueId();
+        Instant now = Instant.now();
+        Instant last = lastSubmission.get(uuid);
+        if (last != null && Duration.between(last, now).compareTo(Duration.ofMinutes(5)) < 0) {
+            sender.sendMessage("You can submit only one suggestion every 5 minutes.");
+            OpenCore.getInstance().getLogger().info("Rate limit hit for " + sender.getName());
             return true;
         }
         if (args.length == 0) {
@@ -36,7 +50,9 @@ public class SuggestCommand implements TabExecutor {
             sender.sendMessage("Ähnlicher Vorschlag existiert bereits.");
             return true;
         }
-        int id = votingService.submitSuggestion(((Player) sender).getUniqueId(), text);
+        lastSubmission.put(uuid, now);
+        OpenCore.getInstance().getLogger().info("Suggestion from " + sender.getName() + " at " + now + ": " + text);
+        int id = votingService.submitSuggestion(uuid, text);
         if (id == -1) {
             sender.sendMessage("Failed to submit suggestion.");
         } else {

--- a/src/main/resources/api.yml
+++ b/src/main/resources/api.yml
@@ -1,1 +1,2 @@
 port: 8080
+expose-reputations: true

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -30,3 +30,5 @@ commands:
     description: Show closed vote results
   editrule:
     description: Edit an existing rule
+  rulehistory:
+    description: Show history for a rule


### PR DESCRIPTION
## Summary
- limit suggestion submissions to one per 5 minutes and log each entry
- expose rule change history via new `getHistory` API and `/rulehistory` command
- show source module in `/myrep`
- add option to disable reputation API endpoint

## Testing
- `mvn test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6844b5df47208323a522870596fc9575