### PR TITLE
Add setup web interface

### DIFF
--- a/src/main/java/com/illusioncis7/opencore/OpenCore.java
+++ b/src/main/java/com/illusioncis7/opencore/OpenCore.java
@@ -39,6 +39,7 @@ public class OpenCore extends JavaPlugin {
     private VotingService votingService;
     private PlanHook planHook;
     private com.illusioncis7.opencore.api.ApiServer apiServer;
+    private com.illusioncis7.opencore.setup.SetupManager setupManager;
 
     public static OpenCore getInstance() {
         return instance;
@@ -54,6 +55,7 @@ public class OpenCore extends JavaPlugin {
         saveResource("reputation.yml", false);
         saveResource("voting.yml", false);
         saveResource("api.yml", false);
+        saveResource("webpanel/index.html", false);
 
         database = new Database(this);
         database.connect();
@@ -64,6 +66,8 @@ public class OpenCore extends JavaPlugin {
         configService.scanAndStore(new File(".").getAbsoluteFile());
 
         ruleService = new RuleService(this, database);
+
+        setupManager = new com.illusioncis7.opencore.setup.SetupManager(this, ruleService, configService);
 
         gptService = new GptService(this, database);
         gptService.init();
@@ -157,7 +161,7 @@ public class OpenCore extends JavaPlugin {
         boolean exposeRep = apiCfg.getBoolean("expose-reputations", true);
         try {
             apiServer = new com.illusioncis7.opencore.api.ApiServer(port, exposeRep, votingService,
-                    reputationService, ruleService, getLogger());
+                    reputationService, ruleService, configService, setupManager, getLogger());
         } catch (Exception e) {
             getLogger().warning("Failed to start API server: " + e.getMessage());
         }
@@ -201,5 +205,9 @@ public class OpenCore extends JavaPlugin {
 
     public VotingService getVotingService() {
         return votingService;
+    }
+
+    public com.illusioncis7.opencore.setup.SetupManager getSetupManager() {
+        return setupManager;
     }
 }

--- a/src/main/java/com/illusioncis7/opencore/api/ApiServer.java
+++ b/src/main/java/com/illusioncis7/opencore/api/ApiServer.java
@@ -2,18 +2,21 @@ package com.illusioncis7.opencore.api;
 
 import com.illusioncis7.opencore.rules.Rule;
 import com.illusioncis7.opencore.rules.RuleService;
+import com.illusioncis7.opencore.config.ConfigService;
+import com.illusioncis7.opencore.config.ConfigParameter;
+import com.illusioncis7.opencore.setup.SetupManager;
 import com.illusioncis7.opencore.reputation.ReputationService;
 import com.illusioncis7.opencore.reputation.ReputationService.PlayerReputation;
 import com.illusioncis7.opencore.voting.Suggestion;
 import com.illusioncis7.opencore.voting.VotingService;
 import com.sun.net.httpserver.HttpExchange;
-import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.InputStream;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
@@ -26,15 +29,19 @@ public class ApiServer {
     private final VotingService votingService;
     private final ReputationService reputationService;
     private final RuleService ruleService;
+    private final ConfigService configService;
+    private final SetupManager setupManager;
     private final Logger logger;
     private HttpServer server;
     private final boolean exposeReputations;
 
     public ApiServer(int port, boolean exposeReputations, VotingService votingService, ReputationService reputationService,
-                     RuleService ruleService, Logger logger) throws IOException {
+                     RuleService ruleService, ConfigService configService, SetupManager setupManager, Logger logger) throws IOException {
         this.votingService = votingService;
         this.reputationService = reputationService;
         this.ruleService = ruleService;
+        this.configService = configService;
+        this.setupManager = setupManager;
         this.logger = logger;
         this.exposeReputations = exposeReputations;
         if (port > 0) {
@@ -53,6 +60,16 @@ public class ApiServer {
         if (exposeReputations) {
             server.createContext("/api/reputations", exchange -> handle(exchange, this::writeReputations));
         }
+
+        server.createContext("/setup/status", this::handleSetupStatus);
+        server.createContext("/setup/rules", this::handleRulesGet);
+        server.createContext("/setup/rules/add", this::handleAddRule);
+        server.createContext("/setup/configs", this::handleConfigsGet);
+        server.createContext("/setup/configs/update", this::handleUpdateConfig);
+        server.createContext("/setup/complete", this::handleComplete);
+
+        server.createContext("/webpanel", this::handleStaticFiles);
+        server.createContext("/webpanel/", this::handleStaticFiles);
     }
 
     private interface JsonWriter {
@@ -112,6 +129,117 @@ public class ApiServer {
             arr.put(o);
         }
         return new JSONObject().put("reputations", arr);
+    }
+
+    /* ===== Setup handlers ===== */
+    private void handleSetupStatus(HttpExchange ex) throws IOException {
+        if (!allowSetup(ex, false)) return;
+        JSONObject obj = new JSONObject();
+        obj.put("setupActive", setupManager.isSetupActive());
+        writeJson(ex, obj);
+    }
+
+    private void handleRulesGet(HttpExchange ex) throws IOException {
+        if (!allowSetup(ex, false)) return;
+        if (!"GET".equalsIgnoreCase(ex.getRequestMethod())) { ex.sendResponseHeaders(405, -1); return; }
+        JSONArray arr = new JSONArray();
+        for (Rule r : ruleService.getRules()) {
+            JSONObject o = new JSONObject();
+            o.put("id", r.id);
+            o.put("text", r.text);
+            o.put("category", r.category);
+            arr.put(o);
+        }
+        writeJson(ex, new JSONObject().put("rules", arr));
+    }
+
+    private void handleAddRule(HttpExchange ex) throws IOException {
+        if (!allowSetup(ex, true)) return;
+        JSONObject req = readJson(ex);
+        String text = req.optString("text", null);
+        String cat = req.optString("category", "");
+        if (text == null) { ex.sendResponseHeaders(400, -1); return; }
+        Rule r = ruleService.addRule(text, cat);
+        JSONObject resp = new JSONObject();
+        resp.put("id", r != null ? r.id : -1);
+        writeJson(ex, resp);
+    }
+
+    private void handleConfigsGet(HttpExchange ex) throws IOException {
+        if (!allowSetup(ex, false)) return;
+        JSONArray arr = new JSONArray();
+        for (ConfigParameter p : configService.listParameters()) {
+            JSONObject o = new JSONObject();
+            o.put("id", p.getId());
+            o.put("name", p.getParameterPath());
+            o.put("type", p.getValueType().name());
+            o.put("value", p.getCurrentValue());
+            o.put("editable", p.isEditable());
+            o.put("min", p.getMinValue());
+            o.put("max", p.getMaxValue());
+            o.put("impact", p.getImpactRating());
+            arr.put(o);
+        }
+        writeJson(ex, new JSONObject().put("parameters", arr));
+    }
+
+    private void handleUpdateConfig(HttpExchange ex) throws IOException {
+        if (!allowSetup(ex, true)) return;
+        JSONObject req = readJson(ex);
+        int id = req.optInt("id", -1);
+        String value = req.optString("value", null);
+        if (id <= 0 || value == null) { ex.sendResponseHeaders(400, -1); return; }
+        boolean ok = configService.updateParameter(id, value, null);
+        writeJson(ex, new JSONObject().put("success", ok));
+    }
+
+    private void handleComplete(HttpExchange ex) throws IOException {
+        if (!allowSetup(ex, true)) return;
+        setupManager.deactivate();
+        writeJson(ex, new JSONObject().put("success", true));
+    }
+
+    private void handleStaticFiles(HttpExchange ex) throws IOException {
+        String path = ex.getRequestURI().getPath().substring("/webpanel".length());
+        if (path.isEmpty() || "/".equals(path)) {
+            path = "/index.html";
+        }
+        java.nio.file.Path file = setupManager.getWebDirectory().toPath().resolve(path.substring(1));
+        if (!java.nio.file.Files.exists(file)) {
+            ex.sendResponseHeaders(404, -1);
+            return;
+        }
+        String mime = path.endsWith(".html") ? "text/html" : "text/plain";
+        ex.getResponseHeaders().add("Content-Type", mime);
+        byte[] data = java.nio.file.Files.readAllBytes(file);
+        ex.sendResponseHeaders(200, data.length);
+        try (OutputStream os = ex.getResponseBody()) {
+            os.write(data);
+        }
+    }
+
+    private JSONObject readJson(HttpExchange ex) throws IOException {
+        try (InputStream is = ex.getRequestBody()) {
+            byte[] data = is.readAllBytes();
+            return new JSONObject(new String(data, StandardCharsets.UTF_8));
+        }
+    }
+
+    private void writeJson(HttpExchange ex, JSONObject obj) throws IOException {
+        byte[] data = obj.toString().getBytes(StandardCharsets.UTF_8);
+        ex.getResponseHeaders().add("Content-Type", "application/json");
+        ex.sendResponseHeaders(200, data.length);
+        try (OutputStream os = ex.getResponseBody()) {
+            os.write(data);
+        }
+    }
+
+    private boolean allowSetup(HttpExchange ex, boolean post) throws IOException {
+        if (!setupManager.isSetupActive()) { ex.sendResponseHeaders(403, -1); return false; }
+        if (post && !"POST".equalsIgnoreCase(ex.getRequestMethod())) { ex.sendResponseHeaders(405, -1); return false; }
+        if (!post && !"GET".equalsIgnoreCase(ex.getRequestMethod())) { ex.sendResponseHeaders(405, -1); return false; }
+        if (!ex.getRemoteAddress().getAddress().isLoopbackAddress()) { ex.sendResponseHeaders(403, -1); return false; }
+        return true;
     }
 
     public void stop() {

--- a/src/main/java/com/illusioncis7/opencore/config/ConfigService.java
+++ b/src/main/java/com/illusioncis7/opencore/config/ConfigService.java
@@ -342,5 +342,18 @@ public class ConfigService {
         }
         return list;
     }
+
+    /**
+     * Count parameters that currently have a value in their underlying files.
+     */
+    public int countParametersWithValue() {
+        int count = 0;
+        for (ConfigParameter p : listParameters()) {
+            if (p.getCurrentValue() != null) {
+                count++;
+            }
+        }
+        return count;
+    }
 }
 

--- a/src/main/java/com/illusioncis7/opencore/setup/SetupManager.java
+++ b/src/main/java/com/illusioncis7/opencore/setup/SetupManager.java
@@ -1,0 +1,75 @@
+package com.illusioncis7.opencore.setup;
+
+import com.illusioncis7.opencore.config.ConfigService;
+import com.illusioncis7.opencore.rules.RuleService;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.json.JSONObject;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Tracks whether the plugin is in setup mode. The state is persisted to
+ * <code>setup_status.json</code> inside the plugin data folder so the web
+ * interface can work offline.
+ */
+public class SetupManager {
+    private final JavaPlugin plugin;
+    private final File stateFile;
+    private boolean setupActive;
+
+    public SetupManager(JavaPlugin plugin, RuleService ruleService, ConfigService configService) {
+        this.plugin = plugin;
+        this.stateFile = new File(plugin.getDataFolder(), "setup_status.json");
+        loadState(ruleService, configService);
+    }
+
+    private void loadState(RuleService ruleService, ConfigService configService) {
+        if (stateFile.exists()) {
+            try (FileReader fr = new FileReader(stateFile, StandardCharsets.UTF_8)) {
+                char[] buf = new char[(int) stateFile.length()];
+                int len = fr.read(buf);
+                if (len > 0) {
+                    JSONObject obj = new JSONObject(new String(buf, 0, len));
+                    setupActive = obj.optBoolean("setupActive", false);
+                    return;
+                }
+            } catch (Exception e) {
+                plugin.getLogger().warning("Failed to read setup state: " + e.getMessage());
+            }
+        }
+        int rules = ruleService.getRuleCount();
+        int params = configService.countParametersWithValue();
+        setupActive = rules < 5 || params < 3;
+        saveState();
+    }
+
+    public boolean isSetupActive() {
+        return setupActive;
+    }
+
+    public JavaPlugin getPlugin() {
+        return plugin;
+    }
+
+    public File getWebDirectory() {
+        return new File(plugin.getDataFolder(), "webpanel");
+    }
+
+    public void deactivate() {
+        this.setupActive = false;
+        saveState();
+    }
+
+    private void saveState() {
+        try (FileWriter fw = new FileWriter(stateFile, StandardCharsets.UTF_8)) {
+            JSONObject obj = new JSONObject();
+            obj.put("setupActive", setupActive);
+            fw.write(obj.toString());
+        } catch (Exception e) {
+            plugin.getLogger().warning("Failed to save setup state: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/resources/api.yml
+++ b/src/main/resources/api.yml
@@ -1,2 +1,2 @@
-port: 8080
+port: 8963
 expose-reputations: true

--- a/src/main/resources/webpanel/index.html
+++ b/src/main/resources/webpanel/index.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>OpenCore Setup</title>
+<style>
+body{font-family:Arial, sans-serif;margin:20px;}
+.hidden{display:none;}
+table{border-collapse:collapse;}
+th,td{border:1px solid #ccc;padding:4px 8px;}
+</style>
+</head>
+<body>
+<h1>OpenCore Setup</h1>
+<div id="status">Loading...</div>
+<div id="overview" class="hidden">
+<p>Setup-Modus aktiv</p>
+<p>Regeln: <span id="ruleCount"></span></p>
+<p>Parameter: <span id="paramCount"></span></p>
+<button onclick="completeSetup()">Abschließen</button>
+<hr/>
+</div>
+<div id="rules" class="hidden">
+<h2>Regeln</h2>
+<input id="ruleText" placeholder="Regeltext"/>
+<input id="ruleCat" placeholder="Kategorie"/>
+<button onclick="addRule()">Hinzufügen</button>
+<ul id="ruleList"></ul>
+<hr/>
+</div>
+<div id="configs" class="hidden">
+<h2>Konfiguration</h2>
+<table id="cfgTable">
+<thead><tr><th>Name</th><th>Typ</th><th>Wert</th><th>min</th><th>max</th><th>Impact</th><th>Neu</th></tr></thead>
+<tbody></tbody>
+</table>
+<button onclick="saveConfigs()">Speichern</button>
+</div>
+<script>
+async function fetchJson(url,opt){const r=await fetch(url,opt);return await r.json();}
+async function loadStatus(){
+ const data=await fetchJson('/setup/status');
+ if(!data.setupActive){document.getElementById('status').innerText='Setup abgeschlossen';return;}
+ document.getElementById('status').classList.add('hidden');
+ document.querySelectorAll('#overview,#rules,#configs').forEach(e=>e.classList.remove('hidden'));
+ const rules=await fetchJson('/setup/rules');
+ document.getElementById('ruleCount').innerText=rules.rules.length;
+ const list=document.getElementById('ruleList');
+ list.innerHTML='';
+ rules.rules.forEach(r=>{const li=document.createElement('li');li.textContent=r.text+' ('+r.category+')';list.appendChild(li);});
+ const cfg=await fetchJson('/setup/configs');
+ document.getElementById('paramCount').innerText=cfg.parameters.length;
+ const body=document.querySelector('#cfgTable tbody');
+ body.innerHTML='';
+ cfg.parameters.forEach(p=>{const tr=document.createElement('tr');tr.innerHTML='<td>'+p.name+'</td><td>'+p.type+'</td><td>'+p.value+'</td><td>'+p.min+'</td><td>'+p.max+'</td><td>'+p.impact+'</td><td><input data-id="'+p.id+'" value="'+(p.value||'')+'"></td>';body.appendChild(tr);});
+}
+async function addRule(){const text=document.getElementById('ruleText').value;const cat=document.getElementById('ruleCat').value; if(!text)return; await fetch('/setup/rules/add',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({text:text,category:cat})});loadStatus();}
+async function saveConfigs(){const inputs=document.querySelectorAll('#cfgTable tbody input'); for(const i of inputs){await fetch('/setup/configs/update',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({id:i.dataset.id,value:i.value})});}loadStatus();}
+async function completeSetup(){await fetch('/setup/complete',{method:'POST'});alert('Setup abgeschlossen');loadStatus();}
+loadStatus();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- implement `SetupManager` for setup mode
- extend `RuleService` and `ConfigService` to support setup operations
- update `OpenCore` and `ApiServer` to expose setup endpoints
- provide simple webpanel with JS UI
- adjust API default port

## Testing
- `mvn -q -DskipTests compile` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin)*
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_6844bb1ed0fc832388f62657ca2097a0