### PR TITLE
Switch to HikariCP for database pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,5 +18,18 @@ Ein modulares Bukkit-Plugin für Paper 1.21.4, das demokratische Communitysteuer
 - Bukkit Scheduler (async)
 - YAML- und JSON-Konfigurationen
 
+## Datenbankeinrichtung
+In der `database.yml` werden die Zugangsdaten für die MariaDB hinterlegt:
+
+```yml
+host: localhost
+port: 3306
+database: opencore
+username: root
+password: password
+```
+
+OpenCore nutzt einen HikariCP-Pool mit zehn Verbindungen. Beim Start wird ein Ping ausgeführt und im Log ausgegeben.
+
 ## 🧠 Ziel
 Ein Server, der durch Spieler gesteuert, durch GPT unterstützt und durch klare Regeln geschützt wird.

--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,11 @@
             <version>3.3.3</version>
         </dependency>
         <dependency>
+            <groupId>com.zaxxer</groupId>
+            <artifactId>HikariCP</artifactId>
+            <version>5.1.0</version>
+        </dependency>
+        <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
             <version>20240303</version>

--- a/src/main/java/com/illusioncis7/opencore/config/ConfigService.java
+++ b/src/main/java/com/illusioncis7/opencore/config/ConfigService.java
@@ -110,7 +110,7 @@ public class ConfigService {
     }
 
     private void insertParameter(String path, String parameter) {
-        if (database.getConnection() == null) {
+        if (!database.isConnected()) {
             return;
         }
 
@@ -133,7 +133,7 @@ public class ConfigService {
      * Update a configuration parameter by ID with a new value.
      */
     public boolean updateParameter(int id, String newValue, UUID changedBy) {
-        if (database.getConnection() == null) {
+        if (!database.isConnected()) {
             return false;
         }
 
@@ -268,7 +268,7 @@ public class ConfigService {
     }
 
     private void logChange(int paramId, Object oldVal, Object newVal, UUID player) {
-        if (database.getConnection() == null) return;
+        if (!database.isConnected()) return;
         String sql = "INSERT INTO config_change_history (change_id, player_uuid, param_key, old_value, new_value, changed_at) VALUES (?, ?, ?, ?, ?, ?)";
         try (Connection conn = database.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql)) {
@@ -292,7 +292,7 @@ public class ConfigService {
      * Rollback a change by applying the stored old value.
      */
     public boolean rollbackChange(UUID changeId) {
-        if (database.getConnection() == null) return false;
+        if (!database.isConnected()) return false;
         String sql = "SELECT param_key, old_value FROM config_change_history WHERE change_id = ?";
         try (Connection conn = database.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql)) {
@@ -315,7 +315,7 @@ public class ConfigService {
      */
     public java.util.List<ConfigParameter> listParameters() {
         java.util.List<ConfigParameter> list = new java.util.ArrayList<>();
-        if (database.getConnection() == null) return list;
+        if (!database.isConnected()) return list;
         String sql = "SELECT id, path, parameter_path, editable, impact_rating, value_type FROM config_params";
         try (Connection conn = database.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql);

--- a/src/main/java/com/illusioncis7/opencore/gpt/GptResponseHandler.java
+++ b/src/main/java/com/illusioncis7/opencore/gpt/GptResponseHandler.java
@@ -49,7 +49,7 @@ public class GptResponseHandler implements Listener {
     }
 
     private void storeResponse(UUID uuid, String module, String response) {
-        if (database.getConnection() == null) {
+        if (!database.isConnected()) {
             return;
         }
         String sql = "INSERT INTO gpt_responses (player_uuid, module, response, created, delivered) VALUES (?, ?, ?, ?, 0)";
@@ -76,7 +76,7 @@ public class GptResponseHandler implements Listener {
     }
 
     private void deliverPending(UUID uuid, Player player) {
-        if (database.getConnection() == null) return;
+        if (!database.isConnected()) return;
         String sql = "SELECT id, module, response FROM gpt_responses WHERE player_uuid = ? AND delivered = 0";
         try (Connection conn = database.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql)) {
@@ -100,7 +100,7 @@ public class GptResponseHandler implements Listener {
     }
 
     private void markDelivered(int id) {
-        if (database.getConnection() == null) return;
+        if (!database.isConnected()) return;
         String sql = "UPDATE gpt_responses SET delivered = 1 WHERE id = ?";
         try (Connection conn = database.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql)) {
@@ -116,7 +116,7 @@ public class GptResponseHandler implements Listener {
      */
     public java.util.List<GptResponseRecord> getRecentResponses(java.util.UUID uuid, int limit) {
         java.util.List<GptResponseRecord> list = new java.util.ArrayList<>();
-        if (database.getConnection() == null) return list;
+        if (!database.isConnected()) return list;
         String sql = "SELECT module, response, created FROM gpt_responses WHERE player_uuid = ? ORDER BY created DESC LIMIT ?";
         try (Connection conn = database.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql)) {

--- a/src/main/java/com/illusioncis7/opencore/gpt/GptService.java
+++ b/src/main/java/com/illusioncis7/opencore/gpt/GptService.java
@@ -253,7 +253,7 @@ public class GptService {
     }
 
     private void logRequest(GptRequest request) {
-        if (database.getConnection() == null) {
+        if (!database.isConnected()) {
             return;
         }
         String sql = "INSERT INTO gpt_log (request_uuid, player_uuid, request_time, prompt) VALUES (?, ?, ?, ?)";
@@ -274,7 +274,7 @@ public class GptService {
     }
 
     private void logResponse(UUID requestId, String response) {
-        if (database.getConnection() == null) {
+        if (!database.isConnected()) {
             return;
         }
         String sql = "UPDATE gpt_log SET response = ?, response_time = ? WHERE request_uuid = ?";

--- a/src/main/java/com/illusioncis7/opencore/gpt/PolicyService.java
+++ b/src/main/java/com/illusioncis7/opencore/gpt/PolicyService.java
@@ -23,7 +23,7 @@ public class PolicyService {
     }
 
     private void initTable() {
-        if (database.getConnection() == null) return;
+        if (!database.isConnected()) return;
         String sql = "CREATE TABLE IF NOT EXISTS gpt_policies (" +
                 "id INT AUTO_INCREMENT PRIMARY KEY," +
                 "name VARCHAR(50) NOT NULL," +
@@ -105,7 +105,7 @@ public class PolicyService {
 
     /** Retrieve the active policy text for the given module. */
     public String getPolicy(String name) {
-        if (database.getConnection() == null) return null;
+        if (!database.isConnected()) return null;
         String sql = "SELECT policy_text FROM gpt_policies WHERE name = ? AND active = 1 ORDER BY version DESC LIMIT 1";
         try (Connection conn = database.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql)) {
@@ -123,7 +123,7 @@ public class PolicyService {
 
     /** Insert a new version of a policy. */
     public void setPolicy(String name, String text) {
-        if (database.getConnection() == null) return;
+        if (!database.isConnected()) return;
         try (Connection conn = database.getConnection()) {
             int version = 1;
             try (PreparedStatement ps = conn.prepareStatement("SELECT MAX(version) FROM gpt_policies WHERE name = ?")) {
@@ -155,7 +155,7 @@ public class PolicyService {
     /** List all policy names. */
     public List<String> listPolicies() {
         List<String> list = new ArrayList<>();
-        if (database.getConnection() == null) return list;
+        if (!database.isConnected()) return list;
         String sql = "SELECT DISTINCT name FROM gpt_policies";
         try (Connection conn = database.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql);
@@ -174,7 +174,7 @@ public class PolicyService {
 
     /** Check whether a policy with the given name exists. */
     public boolean isDefined(String name) {
-        if (database.getConnection() == null) return defaults.containsKey(name);
+        if (!database.isConnected()) return defaults.containsKey(name);
         String sql = "SELECT COUNT(*) FROM gpt_policies WHERE name = ?";
         try (Connection conn = database.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql)) {

--- a/src/main/java/com/illusioncis7/opencore/logging/ChatLogger.java
+++ b/src/main/java/com/illusioncis7/opencore/logging/ChatLogger.java
@@ -23,7 +23,7 @@ public class ChatLogger implements Listener {
 
     @EventHandler
     public void onPlayerChat(AsyncPlayerChatEvent event) {
-        if (database.getConnection() == null) {
+        if (!database.isConnected()) {
             return;
         }
         String sql = "INSERT INTO chat_log (player_uuid, message_time, message) VALUES (?, ?, ?)";

--- a/src/main/java/com/illusioncis7/opencore/reputation/ChatAnalyzerTask.java
+++ b/src/main/java/com/illusioncis7/opencore/reputation/ChatAnalyzerTask.java
@@ -113,7 +113,7 @@ public class ChatAnalyzerTask extends BukkitRunnable {
     }
 
     private UUID resolveAlias(String alias) {
-        if (database.getConnection() == null) return null;
+        if (!database.isConnected()) return null;
         String sql = "SELECT uuid FROM player_registry WHERE alias_id = ?";
         try (Connection conn = database.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql)) {
@@ -150,7 +150,7 @@ public class ChatAnalyzerTask extends BukkitRunnable {
 
     private List<ChatMessage> loadMessages(Instant since) {
         List<ChatMessage> list = new ArrayList<>();
-        if (database.getConnection() == null) {
+        if (!database.isConnected()) {
             return list;
         }
         String sql = "SELECT id, player_uuid, message, message_time FROM chat_log WHERE message_time > ?";
@@ -174,7 +174,7 @@ public class ChatAnalyzerTask extends BukkitRunnable {
     }
 
     private String getAlias(UUID uuid) {
-        if (database.getConnection() == null) return null;
+        if (!database.isConnected()) return null;
         String sql = "SELECT alias_id FROM player_registry WHERE uuid = ?";
         try (Connection conn = database.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql)) {
@@ -191,7 +191,7 @@ public class ChatAnalyzerTask extends BukkitRunnable {
     }
 
     private void logAnalysis(String chatlog, String json, java.util.Set<UUID> players) {
-        if (database.getConnection() == null) return;
+        if (!database.isConnected()) return;
         String sql = "INSERT INTO chat_analysis_log (timestamp, chatlog, json, betroffene_spieler) VALUES (?, ?, ?, ?)";
         try (Connection conn = database.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql)) {

--- a/src/main/java/com/illusioncis7/opencore/reputation/ChatReputationFlagService.java
+++ b/src/main/java/com/illusioncis7/opencore/reputation/ChatReputationFlagService.java
@@ -27,7 +27,7 @@ public class ChatReputationFlagService {
     }
 
     private void initTable() {
-        if (database.getConnection() == null) return;
+        if (!database.isConnected()) return;
         String sql = "CREATE TABLE IF NOT EXISTS chat_reputation_flags (" +
                 "id INT AUTO_INCREMENT PRIMARY KEY," +
                 "code VARCHAR(50) NOT NULL," +
@@ -57,7 +57,7 @@ public class ChatReputationFlagService {
 
     private List<ReputationFlag> loadFlags(boolean activeOnly) {
         List<ReputationFlag> list = new ArrayList<>();
-        if (database.getConnection() == null) return list;
+        if (!database.isConnected()) return list;
         String sql = "SELECT code, description, min_change, max_change, active FROM chat_reputation_flags";
         if (activeOnly) {
             sql += " WHERE active = 1";
@@ -81,7 +81,7 @@ public class ChatReputationFlagService {
 
     /** Find a flag by code. */
     public Optional<ReputationFlag> getFlagByCode(String code) {
-        if (database.getConnection() == null) return Optional.empty();
+        if (!database.isConnected()) return Optional.empty();
         String sql = "SELECT code, description, min_change, max_change, active FROM chat_reputation_flags WHERE code = ?";
         try (Connection conn = database.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql)) {
@@ -109,7 +109,7 @@ public class ChatReputationFlagService {
 
     /** Update min/max values for a flag. */
     public boolean setRange(String code, int min, int max) {
-        if (database.getConnection() == null) return false;
+        if (!database.isConnected()) return false;
         String sql = "UPDATE chat_reputation_flags SET min_change = ?, max_change = ?, last_updated = ? WHERE code = ?";
         try (Connection conn = database.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql)) {
@@ -126,7 +126,7 @@ public class ChatReputationFlagService {
 
     /** Create a new flag. */
     public boolean createFlag(String code, String desc, int min, int max, boolean active) {
-        if (database.getConnection() == null) return false;
+        if (!database.isConnected()) return false;
         String sql = "INSERT INTO chat_reputation_flags (code, description, min_change, max_change, active, last_updated) VALUES (?, ?, ?, ?, ?, ?)";
         try (Connection conn = database.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql)) {
@@ -145,7 +145,7 @@ public class ChatReputationFlagService {
 
     /** Update full flag record. */
     public boolean updateFlag(String code, String desc, int min, int max, boolean active) {
-        if (database.getConnection() == null) return false;
+        if (!database.isConnected()) return false;
         String sql = "UPDATE chat_reputation_flags SET description = ?, min_change = ?, max_change = ?, active = ?, last_updated = ? WHERE code = ?";
         try (Connection conn = database.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql)) {

--- a/src/main/java/com/illusioncis7/opencore/reputation/ReputationService.java
+++ b/src/main/java/com/illusioncis7/opencore/reputation/ReputationService.java
@@ -89,7 +89,7 @@ public class ReputationService {
     }
 
     public synchronized void adjustReputation(UUID playerUuid, int delta, String reason, String source, String detailsJson) {
-        if (database.getConnection() == null) {
+        if (!database.isConnected()) {
             return;
         }
         if (delta == 0) {
@@ -120,7 +120,7 @@ public class ReputationService {
      * @param newValue   new reputation value
      */
     public synchronized void setReputation(UUID playerUuid, int newValue) {
-        if (database.getConnection() == null) {
+        if (!database.isConnected()) {
             return;
         }
         newValue = Math.max(minScore, Math.min(maxScore, newValue));
@@ -156,7 +156,7 @@ public class ReputationService {
      * Fetch a specific reputation event.
      */
     public synchronized ReputationEvent getEvent(UUID eventId) {
-        if (database.getConnection() == null) return null;
+        if (!database.isConnected()) return null;
         String sql = "SELECT timestamp, player_uuid, change, reason_summary, source_module, details FROM reputation_events WHERE id = ?";
         try (Connection conn = database.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql)) {
@@ -213,7 +213,7 @@ public class ReputationService {
     }
 
     public synchronized int getReputation(UUID playerUuid) {
-        if (database.getConnection() == null) {
+        if (!database.isConnected()) {
             return 0;
         }
         String sql = "SELECT reputation_score FROM player_registry WHERE uuid = ?";
@@ -233,7 +233,7 @@ public class ReputationService {
 
     public synchronized List<ReputationEvent> getHistory(UUID playerUuid) {
         List<ReputationEvent> list = new ArrayList<>();
-        if (database.getConnection() == null) {
+        if (!database.isConnected()) {
             return list;
         }
         String sql = "SELECT id, timestamp, change, reason_summary, source_module, details FROM reputation_events WHERE player_uuid = ? ORDER BY timestamp";
@@ -262,7 +262,7 @@ public class ReputationService {
      */
     public synchronized List<PlayerReputation> listReputations() {
         List<PlayerReputation> list = new ArrayList<>();
-        if (database.getConnection() == null) {
+        if (!database.isConnected()) {
             return list;
         }
         String sql = "SELECT uuid, reputation_score FROM player_registry";
@@ -286,7 +286,7 @@ public class ReputationService {
      * with a random alias and reputation score of 0.
      */
     public synchronized void registerPlayer(UUID playerUuid) {
-        if (database.getConnection() == null) {
+        if (!database.isConnected()) {
             return;
         }
         try (Connection conn = database.getConnection()) {

--- a/src/main/java/com/illusioncis7/opencore/rules/RuleService.java
+++ b/src/main/java/com/illusioncis7/opencore/rules/RuleService.java
@@ -29,7 +29,7 @@ public class RuleService {
      * Return the number of stored rules.
      */
     public int getRuleCount() {
-        if (database.getConnection() == null) return 0;
+        if (!database.isConnected()) return 0;
         String sql = "SELECT COUNT(*) FROM server_rules";
         try (Connection conn = database.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql);
@@ -49,7 +49,7 @@ public class RuleService {
      * @return the created Rule or null on failure
      */
     public Rule addRule(String text, String category) {
-        if (database.getConnection() == null) return null;
+        if (!database.isConnected()) return null;
         String sql = "INSERT INTO server_rules (rule_text, category) VALUES (?, ?)";
         try (Connection conn = database.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
@@ -70,7 +70,7 @@ public class RuleService {
 
     public List<Rule> getRules() {
         List<Rule> list = new ArrayList<>();
-        if (database.getConnection() == null) return list;
+        if (!database.isConnected()) return list;
         String sql = "SELECT id, rule_text, category FROM server_rules ORDER BY id";
         try (Connection conn = database.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql);
@@ -85,7 +85,7 @@ public class RuleService {
     }
 
     public Rule getRule(int id) {
-        if (database.getConnection() == null) return null;
+        if (!database.isConnected()) return null;
         String sql = "SELECT id, rule_text, category FROM server_rules WHERE id = ?";
         try (Connection conn = database.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql)) {
@@ -106,7 +106,7 @@ public class RuleService {
      */
     public List<RuleChange> getHistory(int ruleId) {
         List<RuleChange> list = new ArrayList<>();
-        if (database.getConnection() == null) return list;
+        if (!database.isConnected()) return list;
         String sql = "SELECT id, old_text, new_text, changed_at, changed_by, suggestion_id " +
                 "FROM rule_changes WHERE rule_id = ? ORDER BY changed_at";
         try (Connection conn = database.getConnection();
@@ -132,7 +132,7 @@ public class RuleService {
     }
 
     public boolean updateRule(int id, String newText, UUID changedBy, Integer suggestionId) {
-        if (database.getConnection() == null) return false;
+        if (!database.isConnected()) return false;
         String selectSql = "SELECT rule_text FROM server_rules WHERE id = ?";
         String updateSql = "UPDATE server_rules SET rule_text = ? WHERE id = ?";
         String logSql = "INSERT INTO rule_changes (rule_id, old_text, new_text, changed_at, changed_by, suggestion_id) " +

--- a/src/main/java/com/illusioncis7/opencore/voting/GptSuggestionClassifier.java
+++ b/src/main/java/com/illusioncis7/opencore/voting/GptSuggestionClassifier.java
@@ -75,7 +75,7 @@ public class GptSuggestionClassifier {
     }
 
     private void updateSuggestion(int id, SuggestionType type, String reasoning, double confidence) {
-        if (database.getConnection() == null) {
+        if (!database.isConnected()) {
             return;
         }
         String sql = "UPDATE suggestions SET suggestion_type = ?, gpt_reasoning = ?, gpt_confidence = ?, classified_at = ? WHERE id = ?";
@@ -94,7 +94,7 @@ public class GptSuggestionClassifier {
 
     private void handleFailure(int id, String error) {
         logger.warning("GPT classification failed for suggestion " + id + ": " + error);
-        if (database.getConnection() == null) {
+        if (!database.isConnected()) {
             return;
         }
         String sql = "UPDATE suggestions SET gpt_reasoning = ?, classified_at = ? WHERE id = ?";

--- a/src/main/java/com/illusioncis7/opencore/voting/VotingService.java
+++ b/src/main/java/com/illusioncis7/opencore/voting/VotingService.java
@@ -89,7 +89,7 @@ public class VotingService {
     }
 
     private int insertBaseSuggestion(UUID player, String text) {
-        if (database.getConnection() == null) return -1;
+        if (!database.isConnected()) return -1;
         String sql = "INSERT INTO suggestions (player_uuid, parameter_id, new_value, text, created, open) VALUES (?, ?, ?, ?, ?, 1)";
         try (Connection conn = database.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
@@ -176,7 +176,7 @@ public class VotingService {
     }
 
     private void storeRuleInfo(int suggestionId, String summary, int impact) {
-        if (database.getConnection() == null) return;
+        if (!database.isConnected()) return;
         String sql = "UPDATE suggestions SET gpt_reasoning = ?, gpt_confidence = ? WHERE id = ?";
         try (Connection conn = database.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql)) {
@@ -198,7 +198,7 @@ public class VotingService {
     }
 
     private boolean isEditableParam(int paramId) {
-        if (database.getConnection() == null) return false;
+        if (!database.isConnected()) return false;
         String sql = "SELECT editable FROM config_params WHERE id = ?";
         try (Connection conn = database.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql)) {
@@ -215,7 +215,7 @@ public class VotingService {
     }
 
     private void storeMappingError(int suggestionId, String error) {
-        if (database.getConnection() == null) return;
+        if (!database.isConnected()) return;
         String sql = "UPDATE suggestions SET gpt_reasoning = ?, classified_at = ? WHERE id = ?";
         try (Connection conn = database.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql)) {
@@ -229,7 +229,7 @@ public class VotingService {
     }
 
     private void updateMapping(int suggestionId, int paramId, String value) {
-        if (database.getConnection() == null) return;
+        if (!database.isConnected()) return;
         String sql = "UPDATE suggestions SET parameter_id = ?, new_value = ? WHERE id = ?";
         try (Connection conn = database.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql)) {
@@ -246,7 +246,7 @@ public class VotingService {
 
     public List<Suggestion> getOpenSuggestions() {
         List<Suggestion> list = new ArrayList<>();
-        if (database.getConnection() == null) return list;
+        if (!database.isConnected()) return list;
         String sql = "SELECT s.id, s.player_uuid, s.parameter_id, s.new_value, s.text, s.created, s.open, " +
                 "COALESCE(c.description, r.rule_text) " +
                 "FROM suggestions s " +
@@ -274,7 +274,7 @@ public class VotingService {
     }
 
     public boolean isSuggestionOpen(int suggestionId) {
-        if (database.getConnection() == null) return false;
+        if (!database.isConnected()) return false;
         String sql = "SELECT open FROM suggestions WHERE id = ?";
         try (Connection conn = database.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql)) {
@@ -292,7 +292,7 @@ public class VotingService {
 
     public List<Suggestion> getClosedSuggestions() {
         List<Suggestion> list = new ArrayList<>();
-        if (database.getConnection() == null) return list;
+        if (!database.isConnected()) return list;
         String sql = "SELECT s.id, s.player_uuid, s.parameter_id, s.new_value, s.text, s.created, s.open, " +
                 "COALESCE(c.description, r.rule_text) " +
                 "FROM suggestions s " +
@@ -320,7 +320,7 @@ public class VotingService {
     }
 
     public VoteWeights getVoteWeights(int suggestionId) {
-        if (database.getConnection() == null) return new VoteWeights(0, 0, 0);
+        if (!database.isConnected()) return new VoteWeights(0, 0, 0);
 
         int yesWeight = 0;
         int noWeight = 0;
@@ -392,7 +392,7 @@ public class VotingService {
     }
 
     public boolean castVote(UUID player, int suggestionId, boolean yes) {
-        if (database.getConnection() == null) return false;
+        if (!database.isConnected()) return false;
         if (!isSuggestionOpen(suggestionId)) {
             return false;
         }
@@ -416,7 +416,7 @@ public class VotingService {
     }
 
     public boolean hasPlayerVoted(UUID player, int suggestionId) {
-        if (database.getConnection() == null) return false;
+        if (!database.isConnected()) return false;
         String sql = "SELECT 1 FROM votes WHERE suggestion_id = ? AND player_uuid = ?";
         try (Connection conn = database.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql)) {
@@ -432,7 +432,7 @@ public class VotingService {
     }
 
     public boolean isSimilarSuggestionRecent(String text, Duration timeframe, int maxDistance) {
-        if (database.getConnection() == null) return false;
+        if (!database.isConnected()) return false;
         String sql = "SELECT text FROM suggestions WHERE created >= ?";
         Instant since = Instant.now().minus(timeframe);
         try (Connection conn = database.getConnection();
@@ -499,7 +499,7 @@ public class VotingService {
     }
 
     private void evaluateVotes(int suggestionId) {
-        if (database.getConnection() == null) return;
+        if (!database.isConnected()) return;
 
         int yesWeight = 0;
         int noWeight = 0;
@@ -576,7 +576,7 @@ public class VotingService {
     }
 
     private void applySuggestion(int suggestionId) {
-        if (database.getConnection() == null) return;
+        if (!database.isConnected()) return;
         String sql = "SELECT suggestion_type, parameter_id, new_value, player_uuid FROM suggestions WHERE id = ? AND open = 1";
         SuggestionType type = null;
         int paramId = 0;
@@ -636,7 +636,7 @@ public class VotingService {
     }
 
     private int getImplementedCount(UUID player) {
-        if (database.getConnection() == null) return 0;
+        if (!database.isConnected()) return 0;
         String sql = "SELECT COUNT(*) FROM suggestions WHERE player_uuid = ? AND open = 0";
         try (Connection conn = database.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql)) {


### PR DESCRIPTION
## Summary
- add HikariCP dependency
- rewrite `Database` to use HikariCP connection pooling
- adjust services to check `isConnected()` instead of null connection
- document database settings

## Testing
- `mvn -q test` *(fails: PluginResolutionException)*

------
https://chatgpt.com/codex/tasks/task_e_6845575c719c83239ce99e723d0880de