### PR TITLE
Fix SQL reserved keyword issue

### DIFF
--- a/src/main/java/com/illusioncis7/opencore/database/Database.java
+++ b/src/main/java/com/illusioncis7/opencore/database/Database.java
@@ -107,7 +107,7 @@ public class Database {
                     "id VARCHAR(36) PRIMARY KEY," +
                     "timestamp TIMESTAMP NOT NULL," +
                     "player_uuid VARCHAR(36) NOT NULL," +
-                    "change INT NOT NULL," +
+                    "`change` INT NOT NULL," +
                     "reason_summary VARCHAR(255)," +
                     "source_module VARCHAR(50)," +
                     "details TEXT" +

--- a/src/main/java/com/illusioncis7/opencore/reputation/ReputationService.java
+++ b/src/main/java/com/illusioncis7/opencore/reputation/ReputationService.java
@@ -157,7 +157,7 @@ public class ReputationService {
      */
     public synchronized ReputationEvent getEvent(UUID eventId) {
         if (!database.isConnected()) return null;
-        String sql = "SELECT timestamp, player_uuid, change, reason_summary, source_module, details FROM reputation_events WHERE id = ?";
+        String sql = "SELECT timestamp, player_uuid, `change`, reason_summary, source_module, details FROM reputation_events WHERE id = ?";
         try (Connection conn = database.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql)) {
             ps.setString(1, eventId.toString());
@@ -198,7 +198,7 @@ public class ReputationService {
     }
 
     private void insertEvent(Connection conn, UUID playerUuid, int delta, String reason, String source, String detailsJson) throws SQLException {
-        String eventSql = "INSERT INTO reputation_events (id, timestamp, player_uuid, change, reason_summary, source_module, details) VALUES (?, ?, ?, ?, ?, ?, ?)";
+        String eventSql = "INSERT INTO reputation_events (id, timestamp, player_uuid, `change`, reason_summary, source_module, details) VALUES (?, ?, ?, ?, ?, ?, ?)";
         try (PreparedStatement ps = conn.prepareStatement(eventSql)) {
             UUID eventId = UUID.randomUUID();
             ps.setString(1, eventId.toString());
@@ -236,7 +236,7 @@ public class ReputationService {
         if (!database.isConnected()) {
             return list;
         }
-        String sql = "SELECT id, timestamp, change, reason_summary, source_module, details FROM reputation_events WHERE player_uuid = ? ORDER BY timestamp";
+        String sql = "SELECT id, timestamp, `change`, reason_summary, source_module, details FROM reputation_events WHERE player_uuid = ? ORDER BY timestamp";
         try (Connection conn = database.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql)) {
             ps.setString(1, playerUuid.toString());


### PR DESCRIPTION
## Summary
- escape the `change` column name in table creation and queries

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68455d4678d88323965099980fe78a2c