### PR TITLE
Fix Instant formatting in commands

### DIFF
--- a/src/main/java/com/illusioncis7/opencore/gpt/command/GptLogCommand.java
+++ b/src/main/java/com/illusioncis7/opencore/gpt/command/GptLogCommand.java
@@ -32,7 +32,9 @@ public class GptLogCommand implements TabExecutor {
             sender.sendMessage("No GPT responses found.");
             return true;
         }
-        DateTimeFormatter fmt = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+        DateTimeFormatter fmt = DateTimeFormatter
+                .ofPattern("yyyy-MM-dd HH:mm")
+                .withZone(java.time.ZoneId.systemDefault());
         for (GptResponseRecord rec : list) {
             String time = fmt.format(rec.timestamp);
             String prefix = rec.module != null ? "[" + rec.module + "] " : "";

--- a/src/main/java/com/illusioncis7/opencore/reputation/command/MyRepCommand.java
+++ b/src/main/java/com/illusioncis7/opencore/reputation/command/MyRepCommand.java
@@ -32,7 +32,9 @@ public class MyRepCommand implements TabExecutor {
         sender.sendMessage("Your reputation: " + rep);
         List<ReputationEvent> hist = reputationService.getHistory(uuid);
         int start = Math.max(0, hist.size() - 3);
-        DateTimeFormatter fmt = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+        DateTimeFormatter fmt = DateTimeFormatter
+                .ofPattern("yyyy-MM-dd HH:mm")
+                .withZone(java.time.ZoneId.systemDefault());
         for (int i = hist.size() - 1; i >= start; i--) {
             ReputationEvent ev = hist.get(i);
             String time = fmt.format(ev.timestamp);

--- a/src/main/java/com/illusioncis7/opencore/reputation/command/RepInfoCommand.java
+++ b/src/main/java/com/illusioncis7/opencore/reputation/command/RepInfoCommand.java
@@ -47,7 +47,9 @@ public class RepInfoCommand implements TabExecutor {
         List<ReputationEvent> hist = reputationService.getHistory(uuid);
         int pages = (hist.size() + 4) / 5;
         page = Math.max(1, Math.min(page, pages));
-        DateTimeFormatter fmt = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+        DateTimeFormatter fmt = DateTimeFormatter
+                .ofPattern("yyyy-MM-dd HH:mm")
+                .withZone(java.time.ZoneId.systemDefault());
         int start = (page - 1) * 5;
         int end = Math.min(start + 5, hist.size());
         for (int i = start; i < end; i++) {

--- a/src/main/java/com/illusioncis7/opencore/rules/command/RuleHistoryCommand.java
+++ b/src/main/java/com/illusioncis7/opencore/rules/command/RuleHistoryCommand.java
@@ -45,7 +45,9 @@ public class RuleHistoryCommand implements TabExecutor {
         page = Math.max(1, Math.min(page, pages));
         int start = (page - 1) * 5;
         int end = Math.min(start + 5, hist.size());
-        DateTimeFormatter fmt = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+        DateTimeFormatter fmt = DateTimeFormatter
+                .ofPattern("yyyy-MM-dd HH:mm")
+                .withZone(java.time.ZoneId.systemDefault());
         for (int i = start; i < end; i++) {
             RuleChange rc = hist.get(i);
             String time = fmt.format(rc.changedAt);


### PR DESCRIPTION
## Summary
- correctly format `Instant` timestamps by providing a zone to the `DateTimeFormatter`
- update `MyRepCommand`, `RepInfoCommand`, `GptLogCommand` and `RuleHistoryCommand`

## Testing
- `mvn -q test` *(fails: Plugin resolution due to network)*

------
https://chatgpt.com/codex/tasks/task_e_684580d327e4832383a40da1e0f0e239