### PR TITLE
Implement configurable messages

### DIFF
--- a/src/main/java/com/illusioncis7/opencore/OpenCore.java
+++ b/src/main/java/com/illusioncis7/opencore/OpenCore.java
@@ -22,6 +22,7 @@ import com.illusioncis7.opencore.config.command.RollbackConfigCommand;
 import com.illusioncis7.opencore.config.command.ConfigListCommand;
 import com.illusioncis7.opencore.admin.StatusCommand;
 import com.illusioncis7.opencore.plan.PlanHook;
+import com.illusioncis7.opencore.message.MessageService;
 import java.io.File;
 import java.util.Objects;
 
@@ -42,6 +43,7 @@ public class OpenCore extends JavaPlugin {
     private ChatReputationFlagService chatFlagService;
     private VotingService votingService;
     private PlanHook planHook;
+    private MessageService messageService;
     private com.illusioncis7.opencore.api.ApiServer apiServer;
     private com.illusioncis7.opencore.setup.SetupManager setupManager;
 
@@ -59,10 +61,13 @@ public class OpenCore extends JavaPlugin {
         saveResource("reputation.yml", false);
         saveResource("voting.yml", false);
         saveResource("api.yml", false);
+        saveResource("messages.yml", false);
         saveResource("webpanel/index.html", false);
 
         database = new Database(this);
         database.connect();
+
+        messageService = new MessageService(this);
 
         reputationService = new ReputationService(this, database);
         chatFlagService = new ChatReputationFlagService(this, database);
@@ -223,6 +228,10 @@ public class OpenCore extends JavaPlugin {
 
     public VotingService getVotingService() {
         return votingService;
+    }
+
+    public MessageService getMessageService() {
+        return messageService;
     }
 
     public com.illusioncis7.opencore.setup.SetupManager getSetupManager() {

--- a/src/main/java/com/illusioncis7/opencore/admin/StatusCommand.java
+++ b/src/main/java/com/illusioncis7/opencore/admin/StatusCommand.java
@@ -7,6 +7,8 @@ import com.illusioncis7.opencore.voting.VotingService;
 import org.bukkit.command.Command;
 import org.bukkit.command.TabExecutor;
 import org.bukkit.command.CommandSender;
+import com.illusioncis7.opencore.OpenCore;
+import java.util.HashMap;
 
 import java.util.Collections;
 
@@ -30,10 +32,18 @@ public class StatusCommand implements TabExecutor {
         int open = votingService.getOpenSuggestions().size();
         long ping = database.ping();
         long last = gptService.getLastResponseDuration();
-        sender.sendMessage("GPT queue: " + queue);
-        sender.sendMessage("Open suggestions: " + open);
-        sender.sendMessage("DB ping: " + (ping >= 0 ? ping + " ms" : "n/a"));
-        sender.sendMessage("Last GPT response: " + (last >= 0 ? last + " ms" : "n/a"));
+        java.util.Map<String,String> ph = new HashMap<>();
+        ph.put("queue", String.valueOf(queue));
+        OpenCore.getInstance().getMessageService().send(sender, "status.queue", ph);
+        ph = new HashMap<>();
+        ph.put("open", String.valueOf(open));
+        OpenCore.getInstance().getMessageService().send(sender, "status.open", ph);
+        ph = new HashMap<>();
+        ph.put("ping", ping >= 0 ? ping + " ms" : "n/a");
+        OpenCore.getInstance().getMessageService().send(sender, "status.ping", ph);
+        ph = new HashMap<>();
+        ph.put("last", last >= 0 ? last + " ms" : "n/a");
+        OpenCore.getInstance().getMessageService().send(sender, "status.last", ph);
         return true;
     }
 

--- a/src/main/java/com/illusioncis7/opencore/config/command/ConfigListCommand.java
+++ b/src/main/java/com/illusioncis7/opencore/config/command/ConfigListCommand.java
@@ -5,6 +5,8 @@ import com.illusioncis7.opencore.config.ConfigService;
 import org.bukkit.command.Command;
 import org.bukkit.command.TabExecutor;
 import org.bukkit.command.CommandSender;
+import com.illusioncis7.opencore.OpenCore;
+import java.util.HashMap;
 
 import java.util.List;
 
@@ -21,13 +23,18 @@ public class ConfigListCommand implements TabExecutor {
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
         List<ConfigParameter> list = configService.listParameters();
         if (list.isEmpty()) {
-            sender.sendMessage("No parameters found.");
+            OpenCore.getInstance().getMessageService().send(sender, "configlist.none", null);
             return true;
         }
         for (ConfigParameter p : list) {
             String value = p.getCurrentValue() != null ? p.getCurrentValue() : "null";
-            sender.sendMessage("#" + p.getId() + " " + p.getParameterPath() + " = " + value +
-                    " editable=" + p.isEditable() + " impact=" + p.getImpactRating());
+            java.util.Map<String, String> ph = new HashMap<>();
+            ph.put("id", String.valueOf(p.getId()));
+            ph.put("param", p.getParameterPath());
+            ph.put("value", value);
+            ph.put("editable", String.valueOf(p.isEditable()));
+            ph.put("impact", String.valueOf(p.getImpactRating()));
+            OpenCore.getInstance().getMessageService().send(sender, "configlist.entry", ph);
         }
         return true;
     }

--- a/src/main/java/com/illusioncis7/opencore/config/command/RollbackConfigCommand.java
+++ b/src/main/java/com/illusioncis7/opencore/config/command/RollbackConfigCommand.java
@@ -4,6 +4,7 @@ import com.illusioncis7.opencore.config.ConfigService;
 import org.bukkit.command.Command;
 import org.bukkit.command.TabExecutor;
 import org.bukkit.command.CommandSender;
+import com.illusioncis7.opencore.OpenCore;
 
 import java.util.UUID;
 
@@ -23,18 +24,18 @@ public class RollbackConfigCommand implements TabExecutor {
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
         if (args.length < 1) {
-            sender.sendMessage("Usage: /rollbackconfig <changeId>");
+            OpenCore.getInstance().getMessageService().send(sender, "rollbackconfig.usage", null);
             return true;
         }
         try {
             UUID id = UUID.fromString(args[0]);
             if (configService.rollbackChange(id)) {
-                sender.sendMessage("Rollback executed.");
+                OpenCore.getInstance().getMessageService().send(sender, "rollbackconfig.success", null);
             } else {
-                sender.sendMessage("Rollback failed.");
+                OpenCore.getInstance().getMessageService().send(sender, "rollbackconfig.failed", null);
             }
         } catch (IllegalArgumentException e) {
-            sender.sendMessage("Invalid id.");
+            OpenCore.getInstance().getMessageService().send(sender, "rollbackconfig.invalid_id", null);
         }
         return true;
     }

--- a/src/main/java/com/illusioncis7/opencore/gpt/GptResponseHandler.java
+++ b/src/main/java/com/illusioncis7/opencore/gpt/GptResponseHandler.java
@@ -6,6 +6,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
+import com.illusioncis7.opencore.OpenCore;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import java.sql.Connection;
@@ -42,7 +43,14 @@ public class GptResponseHandler implements Listener {
         }
         Player player = Bukkit.getPlayer(request.playerUuid);
         if (player != null && player.isOnline()) {
-            player.sendMessage(response);
+            java.util.Map<String,String> ph = new java.util.HashMap<>();
+            ph.put("text", response);
+            if (request.module != null && !request.module.isEmpty()) {
+                ph.put("module", request.module);
+                OpenCore.getInstance().getMessageService().send(player, "response.module", ph);
+            } else {
+                OpenCore.getInstance().getMessageService().send(player, "response.plain", ph);
+            }
         } else {
             storeResponse(request.playerUuid, request.module, response);
         }
@@ -86,10 +94,13 @@ public class GptResponseHandler implements Listener {
                     int id = rs.getInt(1);
                     String module = rs.getString(2);
                     String text = rs.getString(3);
+                    java.util.Map<String,String> ph = new java.util.HashMap<>();
+                    ph.put("text", text);
                     if (module != null && !module.isEmpty()) {
-                        player.sendMessage("[" + module + "] " + text);
+                        ph.put("module", module);
+                        OpenCore.getInstance().getMessageService().send(player, "response.module", ph);
                     } else {
-                        player.sendMessage(text);
+                        OpenCore.getInstance().getMessageService().send(player, "response.plain", ph);
                     }
                     markDelivered(id);
                 }

--- a/src/main/java/com/illusioncis7/opencore/gpt/command/GptLogCommand.java
+++ b/src/main/java/com/illusioncis7/opencore/gpt/command/GptLogCommand.java
@@ -6,6 +6,8 @@ import org.bukkit.command.Command;
 import org.bukkit.command.TabExecutor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
+import com.illusioncis7.opencore.OpenCore;
+import java.util.HashMap;
 
 import java.time.format.DateTimeFormatter;
 import java.util.List;
@@ -23,13 +25,13 @@ public class GptLogCommand implements TabExecutor {
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
         if (!(sender instanceof Player)) {
-            sender.sendMessage("Players only.");
+            OpenCore.getInstance().getMessageService().send(sender, "gptlog.players_only", null);
             return true;
         }
         UUID uuid = ((Player) sender).getUniqueId();
         List<GptResponseRecord> list = handler.getRecentResponses(uuid, 5);
         if (list.isEmpty()) {
-            sender.sendMessage("No GPT responses found.");
+            OpenCore.getInstance().getMessageService().send(sender, "gptlog.none", null);
             return true;
         }
         DateTimeFormatter fmt = DateTimeFormatter
@@ -37,8 +39,11 @@ public class GptLogCommand implements TabExecutor {
                 .withZone(java.time.ZoneId.systemDefault());
         for (GptResponseRecord rec : list) {
             String time = fmt.format(rec.timestamp);
-            String prefix = rec.module != null ? "[" + rec.module + "] " : "";
-            sender.sendMessage(time + " " + prefix + rec.response);
+            java.util.Map<String,String> ph = new HashMap<>();
+            ph.put("time", time);
+            ph.put("prefix", rec.module != null ? "[" + rec.module + "] " : "");
+            ph.put("response", rec.response);
+            OpenCore.getInstance().getMessageService().send(sender, "gptlog.entry", ph);
         }
         return true;
     }

--- a/src/main/java/com/illusioncis7/opencore/message/MessageService.java
+++ b/src/main/java/com/illusioncis7/opencore/message/MessageService.java
@@ -1,0 +1,67 @@
+package com.illusioncis7.opencore.message;
+
+import org.bukkit.ChatColor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Loads chat messages from messages.yml and applies color codes and placeholders.
+ */
+public class MessageService {
+    private final JavaPlugin plugin;
+    private FileConfiguration config;
+
+    public MessageService(JavaPlugin plugin) {
+        this.plugin = plugin;
+        reload();
+    }
+
+    public void reload() {
+        File file = new File(plugin.getDataFolder(), "messages.yml");
+        if (!file.exists()) {
+            plugin.saveResource("messages.yml", false);
+        }
+        config = YamlConfiguration.loadConfiguration(file);
+    }
+
+    private List<String> loadRaw(String key) {
+        Object val = config.get(key);
+        List<String> lines = new ArrayList<>();
+        if (val instanceof Iterable) {
+            for (Object o : (Iterable<?>) val) {
+                lines.add(String.valueOf(o));
+            }
+        } else if (val != null) {
+            lines.add(String.valueOf(val));
+        }
+        return lines;
+    }
+
+    public List<String> getMessage(String key, Map<String, String> placeholders) {
+        List<String> lines = loadRaw(key);
+        List<String> result = new ArrayList<>();
+        for (String line : lines) {
+            if (placeholders != null) {
+                for (Map.Entry<String, String> e : placeholders.entrySet()) {
+                    line = line.replace("{" + e.getKey() + "}", e.getValue());
+                    line = line.replace("%" + e.getKey() + "%", e.getValue());
+                }
+            }
+            result.add(ChatColor.translateAlternateColorCodes('&', line));
+        }
+        return result;
+    }
+
+    public void send(CommandSender sender, String key, Map<String, String> placeholders) {
+        for (String line : getMessage(key, placeholders)) {
+            sender.sendMessage(line);
+        }
+    }
+}

--- a/src/main/java/com/illusioncis7/opencore/reputation/command/ChatFlagsCommand.java
+++ b/src/main/java/com/illusioncis7/opencore/reputation/command/ChatFlagsCommand.java
@@ -5,6 +5,8 @@ import com.illusioncis7.opencore.reputation.ReputationFlag;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.TabExecutor;
+import com.illusioncis7.opencore.OpenCore;
+import java.util.HashMap;
 
 import java.util.Collections;
 import java.util.List;
@@ -22,22 +24,28 @@ public class ChatFlagsCommand implements TabExecutor {
         if (args.length == 0 || "list".equalsIgnoreCase(args[0])) {
             List<ReputationFlag> list = service.listFlags();
             if (list.isEmpty()) {
-                sender.sendMessage("No flags defined.");
+                OpenCore.getInstance().getMessageService().send(sender, "chatflags.none", null);
                 return true;
             }
             for (ReputationFlag f : list) {
                 String act = f.active ? "active" : "inactive";
-                sender.sendMessage(f.code + ": " + f.minChange + ".." + f.maxChange + " (" + act + ") - " + f.description);
+                java.util.Map<String,String> ph = new HashMap<>();
+                ph.put("code", f.code);
+                ph.put("min", String.valueOf(f.minChange));
+                ph.put("max", String.valueOf(f.maxChange));
+                ph.put("state", act);
+                ph.put("desc", f.description);
+                OpenCore.getInstance().getMessageService().send(sender, "chatflags.entry", ph);
             }
             return true;
         }
         if ("set".equalsIgnoreCase(args[0])) {
             if (!sender.isOp()) {
-                sender.sendMessage("Admins only.");
+                OpenCore.getInstance().getMessageService().send(sender, "reputation.admin_only", null);
                 return true;
             }
             if (args.length < 4) {
-                sender.sendMessage("Usage: /chatflags set <CODE> <min> <max>");
+                OpenCore.getInstance().getMessageService().send(sender, "chatflags.usage_set", null);
                 return true;
             }
             String code = args[1];
@@ -45,16 +53,16 @@ public class ChatFlagsCommand implements TabExecutor {
                 int min = Integer.parseInt(args[2]);
                 int max = Integer.parseInt(args[3]);
                 if (service.setRange(code, min, max)) {
-                    sender.sendMessage("Flag updated.");
+                    OpenCore.getInstance().getMessageService().send(sender, "chatflags.updated", null);
                 } else {
-                    sender.sendMessage("Update failed.");
+                    OpenCore.getInstance().getMessageService().send(sender, "chatflags.update_failed", null);
                 }
             } catch (NumberFormatException e) {
-                sender.sendMessage("Invalid numbers.");
+                OpenCore.getInstance().getMessageService().send(sender, "chatflags.invalid_numbers", null);
             }
             return true;
         }
-        sender.sendMessage("Usage: /chatflags list | set <CODE> <min> <max>");
+        OpenCore.getInstance().getMessageService().send(sender, "chatflags.usage", null);
         return true;
     }
 

--- a/src/main/java/com/illusioncis7/opencore/reputation/command/MyRepCommand.java
+++ b/src/main/java/com/illusioncis7/opencore/reputation/command/MyRepCommand.java
@@ -5,6 +5,8 @@ import com.illusioncis7.opencore.reputation.ReputationService;
 import org.bukkit.command.Command;
 import org.bukkit.command.TabExecutor;
 import org.bukkit.command.CommandSender;
+import com.illusioncis7.opencore.OpenCore;
+import java.util.HashMap;
 import org.bukkit.entity.Player;
 
 import java.time.format.DateTimeFormatter;
@@ -23,13 +25,15 @@ public class MyRepCommand implements TabExecutor {
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
         if (!(sender instanceof Player)) {
-            sender.sendMessage("Players only.");
+            OpenCore.getInstance().getMessageService().send(sender, "reputation.players_only", null);
             return true;
         }
         Player player = (Player) sender;
         UUID uuid = player.getUniqueId();
         int rep = reputationService.getReputation(uuid);
-        sender.sendMessage("Your reputation: " + rep);
+        java.util.Map<String,String> ph = new HashMap<>();
+        ph.put("rep", String.valueOf(rep));
+        OpenCore.getInstance().getMessageService().send(sender, "reputation.your_rep", ph);
         List<ReputationEvent> hist = reputationService.getHistory(uuid);
         int start = Math.max(0, hist.size() - 3);
         DateTimeFormatter fmt = DateTimeFormatter
@@ -38,7 +42,12 @@ public class MyRepCommand implements TabExecutor {
         for (int i = hist.size() - 1; i >= start; i--) {
             ReputationEvent ev = hist.get(i);
             String time = fmt.format(ev.timestamp);
-            sender.sendMessage(time + " - " + ev.reasonSummary + " [" + ev.sourceModule + "] (" + (ev.change >= 0 ? "+" : "") + ev.change + ")");
+            java.util.Map<String,String> line = new HashMap<>();
+            line.put("time", time);
+            line.put("reason", ev.reasonSummary);
+            line.put("module", ev.sourceModule);
+            line.put("change", (ev.change >= 0 ? "+" : "") + String.valueOf(ev.change));
+            OpenCore.getInstance().getMessageService().send(sender, "reputation.event", line);
         }
         return true;
     }

--- a/src/main/java/com/illusioncis7/opencore/reputation/command/RepChangeCommand.java
+++ b/src/main/java/com/illusioncis7/opencore/reputation/command/RepChangeCommand.java
@@ -7,6 +7,8 @@ import org.bukkit.OfflinePlayer;
 import org.bukkit.command.Command;
 import org.bukkit.command.TabExecutor;
 import org.bukkit.command.CommandSender;
+import com.illusioncis7.opencore.OpenCore;
+import java.util.HashMap;
 
 import java.util.UUID;
 import java.util.Collections;
@@ -24,28 +26,36 @@ public class RepChangeCommand implements TabExecutor {
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
         if (!sender.isOp()) {
-            sender.sendMessage("Admins only.");
+            OpenCore.getInstance().getMessageService().send(sender, "reputation.admin_only", null);
             return true;
         }
         if (args.length < 1) {
-            sender.sendMessage("Usage: /repchange <eventId>");
+            OpenCore.getInstance().getMessageService().send(sender, "reputation.repchange_usage", null);
             return true;
         }
         try {
             UUID id = UUID.fromString(args[0]);
             ReputationEvent ev = reputationService.getEvent(id);
             if (ev == null) {
-                sender.sendMessage("Change not found.");
+                OpenCore.getInstance().getMessageService().send(sender, "reputation.change_not_found", null);
                 return true;
             }
             OfflinePlayer p = Bukkit.getOfflinePlayer(ev.playerUuid);
             String name = p != null ? p.getName() : ev.playerUuid.toString();
-            sender.sendMessage("Player: " + name);
-            sender.sendMessage("Value: " + (ev.change >= 0 ? "+" : "") + ev.change);
-            sender.sendMessage("Reason: " + ev.reasonSummary);
-            sender.sendMessage("GPT-Kategorie: " + ev.sourceModule);
+            java.util.Map<String,String> ph = new HashMap<>();
+            ph.put("player", name);
+            OpenCore.getInstance().getMessageService().send(sender, "reputation.change_player", ph);
+            ph = new HashMap<>();
+            ph.put("value", (ev.change >= 0 ? "+" : "") + String.valueOf(ev.change));
+            OpenCore.getInstance().getMessageService().send(sender, "reputation.change_value", ph);
+            ph = new HashMap<>();
+            ph.put("reason", ev.reasonSummary);
+            OpenCore.getInstance().getMessageService().send(sender, "reputation.change_reason", ph);
+            ph = new HashMap<>();
+            ph.put("module", ev.sourceModule);
+            OpenCore.getInstance().getMessageService().send(sender, "reputation.change_module", ph);
         } catch (IllegalArgumentException e) {
-            sender.sendMessage("Invalid ID format.");
+            OpenCore.getInstance().getMessageService().send(sender, "reputation.invalid_id", null);
         }
         return true;
     }

--- a/src/main/java/com/illusioncis7/opencore/reputation/command/RepInfoCommand.java
+++ b/src/main/java/com/illusioncis7/opencore/reputation/command/RepInfoCommand.java
@@ -6,6 +6,8 @@ import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
 import org.bukkit.command.TabExecutor;
 import org.bukkit.command.CommandSender;
+import com.illusioncis7.opencore.OpenCore;
+import java.util.HashMap;
 import org.bukkit.entity.Player;
 
 import java.time.format.DateTimeFormatter;
@@ -24,16 +26,16 @@ public class RepInfoCommand implements TabExecutor {
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
         if (!sender.isOp()) {
-            sender.sendMessage("Admins only.");
+            OpenCore.getInstance().getMessageService().send(sender, "reputation.admin_only", null);
             return true;
         }
         if (args.length < 1) {
-            sender.sendMessage("Usage: /repinfo <player> [page]");
+            OpenCore.getInstance().getMessageService().send(sender, "reputation.repinfo_usage", null);
             return true;
         }
         Player target = Bukkit.getPlayer(args[0]);
         if (target == null) {
-            sender.sendMessage("Player not found.");
+            OpenCore.getInstance().getMessageService().send(sender, "reputation.player_not_found", null);
             return true;
         }
         UUID uuid = target.getUniqueId();
@@ -43,7 +45,10 @@ public class RepInfoCommand implements TabExecutor {
             try { page = Integer.parseInt(args[1]); } catch (NumberFormatException ignore) {}
         }
 
-        sender.sendMessage(target.getName() + " reputation: " + rep);
+        java.util.Map<String,String> head = new HashMap<>();
+        head.put("player", target.getName());
+        head.put("rep", String.valueOf(rep));
+        OpenCore.getInstance().getMessageService().send(sender, "reputation.player_rep", head);
         List<ReputationEvent> hist = reputationService.getHistory(uuid);
         int pages = (hist.size() + 4) / 5;
         page = Math.max(1, Math.min(page, pages));
@@ -55,9 +60,16 @@ public class RepInfoCommand implements TabExecutor {
         for (int i = start; i < end; i++) {
             ReputationEvent ev = hist.get(i);
             String time = fmt.format(ev.timestamp);
-            sender.sendMessage(time + " - " + ev.reasonSummary + " (" + (ev.change >= 0 ? "+" : "") + ev.change + ")");
+            java.util.Map<String,String> ph = new HashMap<>();
+            ph.put("time", time);
+            ph.put("reason", ev.reasonSummary);
+            ph.put("change", (ev.change >= 0 ? "+" : "") + String.valueOf(ev.change));
+            OpenCore.getInstance().getMessageService().send(sender, "reputation.event", ph);
         }
-        sender.sendMessage("Page " + page + "/" + pages);
+        java.util.Map<String,String> pmap = new HashMap<>();
+        pmap.put("page", String.valueOf(page));
+        pmap.put("pages", String.valueOf(pages));
+        OpenCore.getInstance().getMessageService().send(sender, "reputation.page", pmap);
         return true;
     }
 

--- a/src/main/java/com/illusioncis7/opencore/rules/command/EditRuleCommand.java
+++ b/src/main/java/com/illusioncis7/opencore/rules/command/EditRuleCommand.java
@@ -4,6 +4,8 @@ import com.illusioncis7.opencore.rules.RuleService;
 import org.bukkit.command.Command;
 import org.bukkit.command.TabExecutor;
 import org.bukkit.command.CommandSender;
+import com.illusioncis7.opencore.OpenCore;
+import java.util.HashMap;
 import org.bukkit.entity.Player;
 
 import java.util.Arrays;
@@ -22,22 +24,22 @@ public class EditRuleCommand implements TabExecutor {
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
         if (args.length < 2) {
-            sender.sendMessage("Usage: /editrule <id> <new text>");
+            OpenCore.getInstance().getMessageService().send(sender, "editrule.usage", null);
             return true;
         }
         int id;
         try {
             id = Integer.parseInt(args[0]);
         } catch (NumberFormatException e) {
-            sender.sendMessage("Invalid id.");
+            OpenCore.getInstance().getMessageService().send(sender, "editrule.invalid_id", null);
             return true;
         }
         String newText = String.join(" ", Arrays.copyOfRange(args, 1, args.length));
         UUID changer = sender instanceof Player ? ((Player) sender).getUniqueId() : null;
         if (ruleService.updateRule(id, newText, changer, null)) {
-            sender.sendMessage("Rule updated.");
+            OpenCore.getInstance().getMessageService().send(sender, "editrule.updated", null);
         } else {
-            sender.sendMessage("Failed to update rule.");
+            OpenCore.getInstance().getMessageService().send(sender, "editrule.failed", null);
         }
         return true;
     }

--- a/src/main/java/com/illusioncis7/opencore/rules/command/RuleHistoryCommand.java
+++ b/src/main/java/com/illusioncis7/opencore/rules/command/RuleHistoryCommand.java
@@ -6,6 +6,8 @@ import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.TabExecutor;
+import com.illusioncis7.opencore.OpenCore;
+import java.util.HashMap;
 
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -22,14 +24,14 @@ public class RuleHistoryCommand implements TabExecutor {
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
         if (args.length < 1) {
-            sender.sendMessage("Usage: /rulehistory <id> [page]");
+            OpenCore.getInstance().getMessageService().send(sender, "rulehistory.usage", null);
             return true;
         }
         int id;
         try {
             id = Integer.parseInt(args[0]);
         } catch (NumberFormatException e) {
-            sender.sendMessage("Invalid id.");
+            OpenCore.getInstance().getMessageService().send(sender, "rulehistory.invalid_id", null);
             return true;
         }
         int page = 1;
@@ -38,7 +40,7 @@ public class RuleHistoryCommand implements TabExecutor {
         }
         List<RuleChange> hist = ruleService.getHistory(id);
         if (hist.isEmpty()) {
-            sender.sendMessage("No history found.");
+            OpenCore.getInstance().getMessageService().send(sender, "rulehistory.no_history", null);
             return true;
         }
         int pages = (hist.size() + 4) / 5;
@@ -52,9 +54,16 @@ public class RuleHistoryCommand implements TabExecutor {
             RuleChange rc = hist.get(i);
             String time = fmt.format(rc.changedAt);
             String changer = rc.changedBy != null ? Bukkit.getOfflinePlayer(rc.changedBy).getName() : "system";
-            sender.sendMessage(time + " by " + changer + ": " + rc.newText);
+            java.util.Map<String, String> ph = new HashMap<>();
+            ph.put("time", time);
+            ph.put("changer", changer);
+            ph.put("text", rc.newText);
+            OpenCore.getInstance().getMessageService().send(sender, "rulehistory.entry", ph);
         }
-        sender.sendMessage("Page " + page + "/" + pages);
+        java.util.Map<String, String> ph = new HashMap<>();
+        ph.put("page", String.valueOf(page));
+        ph.put("pages", String.valueOf(pages));
+        OpenCore.getInstance().getMessageService().send(sender, "rulehistory.page", ph);
         return true;
     }
 

--- a/src/main/java/com/illusioncis7/opencore/rules/command/RulesCommand.java
+++ b/src/main/java/com/illusioncis7/opencore/rules/command/RulesCommand.java
@@ -5,6 +5,8 @@ import com.illusioncis7.opencore.rules.RuleService;
 import org.bukkit.command.Command;
 import org.bukkit.command.TabExecutor;
 import org.bukkit.command.CommandSender;
+import com.illusioncis7.opencore.OpenCore;
+import java.util.HashMap;
 
 import java.util.List;
 import java.util.ArrayList;
@@ -24,12 +26,16 @@ public class RulesCommand implements TabExecutor {
                 int id = Integer.parseInt(args[1]);
                 Rule r = ruleService.getRule(id);
                 if (r == null) {
-                    sender.sendMessage("Rule not found.");
+                    OpenCore.getInstance().getMessageService().send(sender, "rules.not_found", null);
                 } else {
-                    sender.sendMessage("#" + r.id + " [" + r.category + "]: " + r.text);
+                    java.util.Map<String,String> ph = new HashMap<>();
+                    ph.put("id", String.valueOf(r.id));
+                    ph.put("category", r.category);
+                    ph.put("text", r.text);
+                    OpenCore.getInstance().getMessageService().send(sender, "rules.entry", ph);
                 }
             } catch (NumberFormatException e) {
-                sender.sendMessage("Invalid id.");
+                OpenCore.getInstance().getMessageService().send(sender, "rules.invalid_id", null);
             }
             return true;
         }
@@ -41,7 +47,7 @@ public class RulesCommand implements TabExecutor {
 
         List<Rule> rules = ruleService.getRules();
         if (rules.isEmpty()) {
-            sender.sendMessage("No rules defined.");
+            OpenCore.getInstance().getMessageService().send(sender, "rules.none", null);
             return true;
         }
         int pages = (rules.size() + 4) / 5;
@@ -50,9 +56,16 @@ public class RulesCommand implements TabExecutor {
         int end = Math.min(start + 5, rules.size());
         for (int i = start; i < end; i++) {
             Rule r = rules.get(i);
-            sender.sendMessage("#" + r.id + " [" + r.category + "]: " + r.text);
+            java.util.Map<String,String> ph = new HashMap<>();
+            ph.put("id", String.valueOf(r.id));
+            ph.put("category", r.category);
+            ph.put("text", r.text);
+            OpenCore.getInstance().getMessageService().send(sender, "rules.entry", ph);
         }
-        sender.sendMessage("Page " + page + "/" + pages);
+        java.util.Map<String,String> ph = new HashMap<>();
+        ph.put("page", String.valueOf(page));
+        ph.put("pages", String.valueOf(pages));
+        OpenCore.getInstance().getMessageService().send(sender, "rules.page", ph);
         return true;
     }
 

--- a/src/main/java/com/illusioncis7/opencore/voting/command/SuggestionsCommand.java
+++ b/src/main/java/com/illusioncis7/opencore/voting/command/SuggestionsCommand.java
@@ -6,6 +6,8 @@ import com.illusioncis7.opencore.voting.VotingService.VoteWeights;
 import org.bukkit.command.Command;
 import org.bukkit.command.TabExecutor;
 import org.bukkit.command.CommandSender;
+import com.illusioncis7.opencore.OpenCore;
+import java.util.HashMap;
 
 import java.util.List;
 import java.util.ArrayList;
@@ -28,7 +30,7 @@ public class SuggestionsCommand implements TabExecutor {
         }
         List<Suggestion> list = votingService.getOpenSuggestions();
         if (list.isEmpty()) {
-            sender.sendMessage("No open suggestions.");
+            OpenCore.getInstance().getMessageService().send(sender, "suggestions.none", null);
             return true;
         }
         int pages = (list.size() + PAGE_SIZE - 1) / PAGE_SIZE;
@@ -42,12 +44,24 @@ public class SuggestionsCommand implements TabExecutor {
             String title = (s.description != null && !s.description.isEmpty()) ? s.description : s.text;
             String progress = w.yesWeight + "/" + w.requiredWeight + " yes";
             if (remaining > 0) {
-                sender.sendMessage("#" + s.id + " - " + title + " [" + progress + "] " + remaining + " votes needed");
+                java.util.Map<String,String> ph = new HashMap<>();
+                ph.put("id", String.valueOf(s.id));
+                ph.put("title", title);
+                ph.put("progress", progress);
+                ph.put("remaining", String.valueOf(remaining));
+                OpenCore.getInstance().getMessageService().send(sender, "suggestions.entry_need", ph);
             } else {
-                sender.sendMessage("#" + s.id + " - " + title + " [" + progress + "] quorum reached");
+                java.util.Map<String,String> ph = new HashMap<>();
+                ph.put("id", String.valueOf(s.id));
+                ph.put("title", title);
+                ph.put("progress", progress);
+                OpenCore.getInstance().getMessageService().send(sender, "suggestions.entry_quorum", ph);
             }
         }
-        sender.sendMessage("Page " + page + "/" + pages);
+        java.util.Map<String,String> ph = new HashMap<>();
+        ph.put("page", String.valueOf(page));
+        ph.put("pages", String.valueOf(pages));
+        OpenCore.getInstance().getMessageService().send(sender, "suggestions.page", ph);
         return true;
     }
 

--- a/src/main/java/com/illusioncis7/opencore/voting/command/VoteCommand.java
+++ b/src/main/java/com/illusioncis7/opencore/voting/command/VoteCommand.java
@@ -7,6 +7,7 @@ import org.bukkit.command.Command;
 import org.bukkit.command.TabExecutor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
+import java.util.HashMap;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -21,11 +22,11 @@ public class VoteCommand implements TabExecutor {
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
         if (!(sender instanceof Player)) {
-            sender.sendMessage("Players only.");
+            OpenCore.getInstance().getMessageService().send(sender, "vote.players_only", null);
             return true;
         }
         if (args.length < 2) {
-            sender.sendMessage("Usage: /vote <id> <yes|no>");
+            OpenCore.getInstance().getMessageService().send(sender, "vote.usage", null);
             return true;
         }
         try {
@@ -33,12 +34,12 @@ public class VoteCommand implements TabExecutor {
             boolean yes = args[1].equalsIgnoreCase("yes") || args[1].equalsIgnoreCase("y");
             Player player = (Player) sender;
             if (votingService.hasPlayerVoted(player.getUniqueId(), id)) {
-                sender.sendMessage("Du hast bereits abgestimmt.");
+                OpenCore.getInstance().getMessageService().send(sender, "vote.already", null);
                 return true;
             }
             boolean success = votingService.castVote(player.getUniqueId(), id, yes);
             if (!success) {
-                sender.sendMessage("Unknown or closed suggestion.");
+                OpenCore.getInstance().getMessageService().send(sender, "vote.unknown", null);
                 OpenCore.getInstance().getLogger().warning("Invalid vote from " + sender.getName() + " for " + id);
                 return true;
             }
@@ -46,15 +47,17 @@ public class VoteCommand implements TabExecutor {
                 com.illusioncis7.opencore.voting.VotingService.VoteWeights w = votingService.getVoteWeights(id);
                 int remaining = Math.max(0, w.requiredWeight - w.yesWeight);
                 if (remaining > 0) {
-                    sender.sendMessage("Noch " + remaining + " Stimmen nötig.");
+                    java.util.Map<String,String> ph = new HashMap<>();
+                    ph.put("remaining", String.valueOf(remaining));
+                    OpenCore.getInstance().getMessageService().send(sender, "vote.remaining", ph);
                 } else {
-                    sender.sendMessage("Quorum erreicht – Voting endet");
+                    OpenCore.getInstance().getMessageService().send(sender, "vote.quorum", null);
                 }
             } else {
-                sender.sendMessage("Voting concluded.");
+                OpenCore.getInstance().getMessageService().send(sender, "vote.concluded", null);
             }
         } catch (NumberFormatException e) {
-            sender.sendMessage("Invalid id.");
+            OpenCore.getInstance().getMessageService().send(sender, "vote.invalid_id", null);
         }
         return true;
     }

--- a/src/main/java/com/illusioncis7/opencore/voting/command/VoteStatusCommand.java
+++ b/src/main/java/com/illusioncis7/opencore/voting/command/VoteStatusCommand.java
@@ -6,6 +6,8 @@ import com.illusioncis7.opencore.voting.VotingService.VoteWeights;
 import org.bukkit.command.Command;
 import org.bukkit.command.TabExecutor;
 import org.bukkit.command.CommandSender;
+import com.illusioncis7.opencore.OpenCore;
+import java.util.HashMap;
 
 import java.util.List;
 import java.util.Collections;
@@ -21,7 +23,7 @@ public class VoteStatusCommand implements TabExecutor {
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
         List<Suggestion> list = votingService.getClosedSuggestions();
         if (list.isEmpty()) {
-            sender.sendMessage("Keine abgeschlossenen Vorschläge.");
+            OpenCore.getInstance().getMessageService().send(sender, "votestatus.none", null);
             return true;
         }
         for (Suggestion s : list) {
@@ -30,7 +32,12 @@ public class VoteStatusCommand implements TabExecutor {
             String title = (s.description != null && !s.description.isEmpty()) ? s.description : s.text;
             String result = accepted ? "angenommen" : "abgelehnt";
             String change = s.newValue != null ? s.newValue : "";
-            sender.sendMessage("#" + s.id + " - " + title + " -> " + result + (accepted && !change.isEmpty() ? ": " + change : ""));
+            java.util.Map<String,String> ph = new HashMap<>();
+            ph.put("id", String.valueOf(s.id));
+            ph.put("title", title);
+            ph.put("result", result);
+            ph.put("change", accepted && !change.isEmpty() ? ": " + change : "");
+            OpenCore.getInstance().getMessageService().send(sender, "votestatus.entry", ph);
         }
         return true;
     }

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -1,0 +1,99 @@
+rulehistory:
+  usage: "&cUsage: /rulehistory <id> [page]"
+  invalid_id: "&cInvalid id."
+  no_history: "&cNo history found."
+  entry: "&7{time} &8by &e{changer}&7: {text}"
+  page: "&7Page {page}/{pages}"
+
+editrule:
+  usage: "&cUsage: /editrule <id> <new text>"
+  invalid_id: "&cInvalid id."
+  updated: "&aRule updated."
+  failed: "&cFailed to update rule."
+
+rules:
+  not_found: "&cRule not found."
+  entry: "&e#{id} [&6{category}&e]: {text}"
+  invalid_id: "&cInvalid id."
+  none: "&cNo rules defined."
+  page: "&7Page {page}/{pages}"
+
+configlist:
+  none: "&cNo parameters found."
+  entry: "&e#{id} {param}= {value} editable={editable} impact={impact}"
+
+rollbackconfig:
+  usage: "&cUsage: /rollbackconfig <changeId>"
+  success: "&aRollback executed."
+  failed: "&cRollback failed."
+  invalid_id: "&cInvalid id."
+
+reputation:
+  players_only: "&cPlayers only."
+  your_rep: "&aYour reputation: {rep}"
+  event: "&7{time} - {reason} [&e{module}&7] ({change})"
+  admin_only: "&cAdmins only."
+  repinfo_usage: "&cUsage: /repinfo <player> [page]"
+  player_not_found: "&cPlayer not found."
+  player_rep: "&e{player} reputation: {rep}"
+  page: "&7Page {page}/{pages}"
+  repchange_usage: "&cUsage: /repchange <eventId>"
+  change_not_found: "&cChange not found."
+  change_player: "&ePlayer: {player}"
+  change_value: "&eValue: {value}"
+  change_reason: "&eReason: {reason}"
+  change_module: "&eGPT-Kategorie: {module}"
+  invalid_id: "&cInvalid id."
+
+chatflags:
+  none: "&cNo flags defined."
+  entry: "&e{code}: {min}..{max} ({state}) - {desc}"
+  usage_set: "&cUsage: /chatflags set <CODE> <min> <max>"
+  updated: "&aFlag updated."
+  update_failed: "&cUpdate failed."
+  invalid_numbers: "&cInvalid numbers."
+  usage: "&cUsage: /chatflags list | set <CODE> <min> <max>"
+
+suggest:
+  players_only: "&cPlayers only."
+  rate_limit: "&cYou can submit only one suggestion every 5 minutes."
+  usage: "&cUsage: /suggest <text>"
+  too_short: "&cSuggestion too short."
+  similar: "&c\u00C4hnlicher Vorschlag existiert bereits."
+  failed: "&cFailed to submit suggestion."
+  success: "&aSuggestion submitted with ID {id}."
+
+suggestions:
+  none: "&cNo open suggestions."
+  entry_need: "&e#{id} - {title} [&f{progress}&e] {remaining} votes needed"
+  entry_quorum: "&e#{id} - {title} [&f{progress}&e] quorum reached"
+  page: "&7Page {page}/{pages}"
+
+vote:
+  players_only: "&cPlayers only."
+  usage: "&cUsage: /vote <id> <yes|no>"
+  already: "&cDu hast bereits abgestimmt."
+  unknown: "&cUnknown or closed suggestion."
+  remaining: "&eNoch {remaining} Stimmen n\u00F6tig."
+  quorum: "&aQuorum erreicht \u2013 Voting endet"
+  concluded: "&aVoting concluded."
+  invalid_id: "&cInvalid id."
+
+votestatus:
+  none: "&cKeine abgeschlossenen Vorschl\u00E4ge."
+  entry: "&e#{id} - {title} -> {result}{change}"
+
+status:
+  queue: "&eGPT queue: {queue}"
+  open: "&eOpen suggestions: {open}"
+  ping: "&eDB ping: {ping}"
+  last: "&eLast GPT response: {last}"
+
+gptlog:
+  players_only: "&cPlayers only."
+  none: "&cNo GPT responses found."
+  entry: "&7{time} {prefix}{response}"
+
+response:
+  module: "&e[{module}] {text}"
+  plain: "{text}"


### PR DESCRIPTION
## Summary
- add `MessageService` to load chat lines from `messages.yml`
- load the new service in `OpenCore`
- replace hardcoded `sendMessage` calls with configurable keys
- include default `messages.yml` with placeholders

## Testing
- `mvn -q test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6845937771f883238b3fd6f0a27550d9