### PR TITLE
Introduce reputation-based weighted votes

### DIFF
--- a/src/main/java/com/illusioncis7/opencore/database/Database.java
+++ b/src/main/java/com/illusioncis7/opencore/database/Database.java
@@ -154,7 +154,7 @@ public class Database {
                     "suggestion_id INT NOT NULL," +
                     "player_uuid VARCHAR(36) NOT NULL," +
                     "vote_yes BOOLEAN NOT NULL," +
-                    "weight INT NOT NULL," +
+                    "weight DOUBLE NOT NULL," +
                     "UNIQUE KEY suggestion_player (suggestion_id, player_uuid)" +
                     ")";
             stmt.executeUpdate(voteSql);

--- a/src/main/java/com/illusioncis7/opencore/voting/Vote.java
+++ b/src/main/java/com/illusioncis7/opencore/voting/Vote.java
@@ -7,9 +7,9 @@ public class Vote {
     public final int suggestionId;
     public final UUID playerUuid;
     public final boolean voteYes;
-    public final int weight;
+    public final double weight;
 
-    public Vote(int id, int suggestionId, UUID playerUuid, boolean voteYes, int weight) {
+    public Vote(int id, int suggestionId, UUID playerUuid, boolean voteYes, double weight) {
         this.id = id;
         this.suggestionId = suggestionId;
         this.playerUuid = playerUuid;

--- a/src/main/java/com/illusioncis7/opencore/voting/command/SuggestionsCommand.java
+++ b/src/main/java/com/illusioncis7/opencore/voting/command/SuggestionsCommand.java
@@ -7,6 +7,7 @@ import org.bukkit.command.Command;
 import org.bukkit.command.TabExecutor;
 import org.bukkit.command.CommandSender;
 import com.illusioncis7.opencore.OpenCore;
+import org.bukkit.ChatColor;
 import java.util.HashMap;
 
 import java.util.List;
@@ -40,9 +41,9 @@ public class SuggestionsCommand implements TabExecutor {
         for (int i = start; i < end; i++) {
             Suggestion s = list.get(i);
             VoteWeights w = votingService.getVoteWeights(s.id);
-            int remaining = Math.max(0, w.requiredWeight - w.yesWeight);
+            int remaining = (int) Math.max(0, w.requiredWeight - w.yesWeight);
             String title = (s.description != null && !s.description.isEmpty()) ? s.description : s.text;
-            String progress = w.yesWeight + "/" + w.requiredWeight + " yes";
+            String progress = String.format("%.1f/%.1f yes", w.yesWeight, w.requiredWeight);
             if (remaining > 0) {
                 java.util.Map<String,String> ph = new HashMap<>();
                 ph.put("id", String.valueOf(s.id));
@@ -57,6 +58,9 @@ public class SuggestionsCommand implements TabExecutor {
                 ph.put("progress", progress);
                 OpenCore.getInstance().getMessageService().send(sender, "suggestions.entry_quorum", ph);
             }
+            sender.sendMessage(votingService.buildVoteBar(w.yesWeight, w.noWeight));
+            long mins = votingService.getRemainingMinutes(s.created);
+            sender.sendMessage(org.bukkit.ChatColor.GRAY + "Noch " + mins + " Minuten");
         }
         java.util.Map<String,String> ph = new HashMap<>();
         ph.put("page", String.valueOf(page));

--- a/src/main/java/com/illusioncis7/opencore/voting/command/VoteCommand.java
+++ b/src/main/java/com/illusioncis7/opencore/voting/command/VoteCommand.java
@@ -37,6 +37,11 @@ public class VoteCommand implements TabExecutor {
                 OpenCore.getInstance().getMessageService().send(sender, "vote.already", null);
                 return true;
             }
+            int rep = OpenCore.getInstance().getReputationService().getReputation(player.getUniqueId());
+            if (rep < votingService.getMinVoteReputation()) {
+                OpenCore.getInstance().getMessageService().send(sender, "vote.low_rep", null);
+                return true;
+            }
             boolean success = votingService.castVote(player.getUniqueId(), id, yes);
             if (!success) {
                 OpenCore.getInstance().getMessageService().send(sender, "vote.unknown", null);
@@ -53,6 +58,7 @@ public class VoteCommand implements TabExecutor {
                 } else {
                     OpenCore.getInstance().getMessageService().send(sender, "vote.quorum", null);
                 }
+                sender.sendMessage(votingService.buildVoteBar(w.yesWeight, w.noWeight));
             } else {
                 OpenCore.getInstance().getMessageService().send(sender, "vote.concluded", null);
             }

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -75,6 +75,7 @@ vote:
   players_only: "&cNur f\u00FCr Spieler."
   usage: "&cVerwendung: /vote <id> <yes|no>"
   already: "&cDu hast bereits abgestimmt."
+  low_rep: "&cDeine Reputation ist zu niedrig zum Abstimmen."
   unknown: "&cUnbekannter oder geschlossener Vorschlag."
   remaining: "&eNoch {remaining} Stimmen n\u00F6tig."
   quorum: "&aQuorum erreicht \u2013 Voting endet"

--- a/src/main/resources/voting.yml
+++ b/src/main/resources/voting.yml
@@ -1,1 +1,14 @@
 webhook-url: ""
+min-reputation: -5
+max-reputation: 500
+negative-weight-min: 0.0
+negative-weight-max: 1.0
+positive-weight-min: 1.0
+positive-weight-max: 20.0
+duration-minutes: 2880
+bar-length: 20
+colors:
+  yes: "&a"
+  no: "&c"
+  marker: "&e"
+  frame: "&7"


### PR DESCRIPTION
## Summary
- extend voting configuration with weight and display settings
- use new settings in `VotingService` to compute vote weights and bars
- expose helper methods and ASCII vote bar
- update vote commands to show bars and enforce minimum reputation
- store vote weight as floating point value

## Testing
- `mvn -q -DskipTests=true package` *(fails: Plugin resolution error)*

------
https://chatgpt.com/codex/tasks/task_e_68459c6bc8e48323b8532db6d4cc45e9