### PR TITLE
Fix sync voting task

### DIFF
--- a/src/main/java/com/illusioncis7/opencore/OpenCore.java
+++ b/src/main/java/com/illusioncis7/opencore/OpenCore.java
@@ -167,7 +167,7 @@ public class OpenCore extends JavaPlugin {
             public void run() {
                 votingService.checkOpenSuggestions();
             }
-        }.runTaskTimer(this, 0L, 30 * 60 * 20L);
+        }.runTaskTimerAsynchronously(this, 0L, 30 * 60 * 20L);
 
         getServer().getPluginManager().registerEvents(new ChatLogger(database, getLogger()), this);
         getServer().getPluginManager().registerEvents(new PlayerJoinListener(reputationService, getLogger(), planHook), this);


### PR DESCRIPTION
## Summary
- run the votingService check in an async task to avoid server lag

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845a64289148323bdddfafca76b2e0c