### PR TITLE
Implement reload command

### DIFF
--- a/src/main/java/com/illusioncis7/opencore/OpenCore.java
+++ b/src/main/java/com/illusioncis7/opencore/OpenCore.java
@@ -147,6 +147,10 @@ public class OpenCore extends JavaPlugin {
         Objects.requireNonNull(getCommand("chatflags")).setExecutor(chatFlagsCmd);
         getCommand("chatflags").setTabCompleter(chatFlagsCmd);
 
+        com.illusioncis7.opencore.admin.ReloadCommand reloadCmd = new com.illusioncis7.opencore.admin.ReloadCommand(this);
+        Objects.requireNonNull(getCommand("reload")).setExecutor(reloadCmd);
+        getCommand("reload").setTabCompleter(reloadCmd);
+
         com.illusioncis7.opencore.admin.StatusCommand statusCmd = new com.illusioncis7.opencore.admin.StatusCommand(gptQueueManager, votingService, database, gptService);
         Objects.requireNonNull(getCommand("status")).setExecutor(statusCmd);
         getCommand("status").setTabCompleter(statusCmd);

--- a/src/main/java/com/illusioncis7/opencore/admin/ReloadCommand.java
+++ b/src/main/java/com/illusioncis7/opencore/admin/ReloadCommand.java
@@ -1,0 +1,42 @@
+package com.illusioncis7.opencore.admin;
+
+import com.illusioncis7.opencore.OpenCore;
+import com.illusioncis7.opencore.reputation.ReputationService;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabExecutor;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Reloads plugin configuration files.
+ */
+public class ReloadCommand implements TabExecutor {
+    private final OpenCore plugin;
+
+    public ReloadCommand(OpenCore plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        try {
+            plugin.getMessageService().reload();
+            ReputationService rep = plugin.getReputationService();
+            if (rep != null) {
+                rep.reload();
+            }
+            plugin.getMessageService().send(sender, "reload.success", null);
+        } catch (Exception e) {
+            plugin.getLogger().warning("Failed to reload: " + e.getMessage());
+            plugin.getMessageService().send(sender, "reload.failed", null);
+        }
+        return true;
+    }
+
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+        return Collections.emptyList();
+    }
+}

--- a/src/main/java/com/illusioncis7/opencore/reputation/ReputationService.java
+++ b/src/main/java/com/illusioncis7/opencore/reputation/ReputationService.java
@@ -72,6 +72,12 @@ public class ReputationService {
         }
     }
 
+    /** Reload configuration values from reputation.yml. */
+    public synchronized void reload() {
+        ranges.clear();
+        loadConfig();
+    }
+
     public int computeChange(String key, double value) {
         Range r = ranges.get(key);
         if (r == null) return 0;

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -98,6 +98,10 @@ gptlog:
   none: "&cKeine GPT-Antworten gefunden."
   entry: "&7{time} {prefix}{response}"
 
+reload:
+  success: "&aKonfiguration neu geladen."
+  failed: "&cReload fehlgeschlagen."
+
 response:
   module: "&e[{module}] {text}"
   plain: "{text}"

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -34,3 +34,5 @@ commands:
     description: Show history for a rule
   chatflags:
     description: Manage chat reputation flags
+  reload:
+    description: Reload plugin configuration


### PR DESCRIPTION
## Summary
- add `ReloadCommand` for runtime configuration reload
- expose `reload` command in plugin.yml
- register the reload command during plugin enable
- add reload messages
- allow ReputationService config reload

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845a95676ac83238687780e4c58a7df