### PR TITLE
Add join privacy warning

### DIFF
--- a/src/main/java/com/illusioncis7/opencore/OpenCore.java
+++ b/src/main/java/com/illusioncis7/opencore/OpenCore.java
@@ -174,7 +174,7 @@ public class OpenCore extends JavaPlugin {
         }.runTaskTimerAsynchronously(this, 0L, 30 * 60 * 20L);
 
         getServer().getPluginManager().registerEvents(new ChatLogger(database, getLogger()), this);
-        getServer().getPluginManager().registerEvents(new PlayerJoinListener(reputationService, getLogger(), planHook), this);
+        getServer().getPluginManager().registerEvents(new PlayerJoinListener(reputationService, getLogger(), planHook, messageService), this);
         getServer().getPluginManager().registerEvents(gptResponseHandler, this);
 
         org.bukkit.configuration.file.FileConfiguration apiCfg =

--- a/src/main/java/com/illusioncis7/opencore/reputation/PlayerJoinListener.java
+++ b/src/main/java/com/illusioncis7/opencore/reputation/PlayerJoinListener.java
@@ -3,6 +3,7 @@ package com.illusioncis7.opencore.reputation;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
+import com.illusioncis7.opencore.message.MessageService;
 
 import java.util.UUID;
 import java.util.logging.Logger;
@@ -12,11 +13,13 @@ public class PlayerJoinListener implements Listener {
     private final ReputationService reputationService;
     private final Logger logger;
     private final PlanHook planHook;
+    private final MessageService messageService;
 
-    public PlayerJoinListener(ReputationService reputationService, Logger logger, PlanHook planHook) {
+    public PlayerJoinListener(ReputationService reputationService, Logger logger, PlanHook planHook, MessageService messageService) {
         this.reputationService = reputationService;
         this.logger = logger;
         this.planHook = planHook;
+        this.messageService = messageService;
     }
 
     @EventHandler
@@ -31,5 +34,6 @@ public class PlayerJoinListener implements Listener {
         } catch (Exception e) {
             logger.warning("Failed to register player on join: " + e.getMessage());
         }
+        messageService.send(event.getPlayer(), "join.privacy_warning", null);
     }
 }

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -105,3 +105,8 @@ reload:
 response:
   module: "&e[{module}] {text}"
   plain: "{text}"
+
+join:
+  privacy_warning:
+    - "&cBitte teile keine sensiblen Daten im \u00F6ffentlichen Chat."
+    - "&7Der Chat wird im Discord angezeigt und vom Plugin ausgewertet."


### PR DESCRIPTION
## Summary
- warn players on login about sharing sensitive info in public chat
- make message configurable in `messages.yml`

## Testing
- `mvn -q test` *(fails: Could not resolve maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_6845aaa97d888323ab8903a92369979e