### PR TITLE
Add SQLite option

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,11 @@ Ein modulares Bukkit-Plugin für Paper 1.21.4, das demokratische Communitysteuer
 - YAML- und JSON-Konfigurationen
 
 ## Datenbankeinrichtung
-In der `database.yml` werden die Zugangsdaten für die MariaDB hinterlegt:
+In der `database.yml` kann zwischen einer lokalen SQLite-Datei und einer MariaDB gewählt werden. Standard ist SQLite:
 
 ```yml
+engine: sqlite # oder "mariadb"
+file: opencore.db
 host: localhost
 port: 3306
 database: opencore

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,10 @@
                                     <pattern>org.mariadb</pattern>
                                     <shadedPattern>shaded.org.mariadb</shadedPattern>
                                 </relocation>
+                                <relocation>
+                                    <pattern>org.sqlite</pattern>
+                                    <shadedPattern>shaded.org.sqlite</shadedPattern>
+                                </relocation>
                             </relocations>
                         </configuration>
                     </execution>
@@ -79,6 +83,11 @@
             <groupId>org.mariadb.jdbc</groupId>
             <artifactId>mariadb-java-client</artifactId>
             <version>3.3.3</version>
+        </dependency>
+        <dependency>
+            <groupId>org.xerial</groupId>
+            <artifactId>sqlite-jdbc</artifactId>
+            <version>3.45.1.0</version>
         </dependency>
         <dependency>
             <groupId>com.zaxxer</groupId>

--- a/src/main/java/com/illusioncis7/opencore/database/Database.java
+++ b/src/main/java/com/illusioncis7/opencore/database/Database.java
@@ -12,8 +12,11 @@ import java.sql.*;
 
 public class Database {
 
+    private enum Engine { MARIADB, SQLITE }
+
     private final JavaPlugin plugin;
     private HikariDataSource dataSource;
+    private Engine engine = Engine.SQLITE;
 
     public Database(JavaPlugin plugin) {
         this.plugin = plugin;
@@ -27,22 +30,36 @@ public class Database {
 
             File configFile = new File(plugin.getDataFolder(), "database.yml");
             FileConfiguration config = YamlConfiguration.loadConfiguration(configFile);
-            String host = config.getString("host", "localhost");
-            int port = config.getInt("port", 3306);
-            String database = config.getString("database", "minecraft");
-            String username = config.getString("username", "root");
-            String password = config.getString("password", "");
-
-            String url = "jdbc:mariadb://" + host + ":" + port + "/" + database + "?useSSL=false";
+            String engineStr = config.getString("engine", "sqlite");
+            if (engineStr.equalsIgnoreCase("mariadb")) {
+                engine = Engine.MARIADB;
+            } else {
+                engine = Engine.SQLITE;
+            }
 
             HikariConfig hikariConfig = new HikariConfig();
-            hikariConfig.setDriverClassName("shaded.org.mariadb.jdbc.Driver");
-            hikariConfig.setJdbcUrl(url);
-            hikariConfig.setUsername(username);
-            hikariConfig.setPassword(password);
-            hikariConfig.setMaximumPoolSize(10);
+            if (engine == Engine.SQLITE) {
+                String file = config.getString("file", "opencore.db");
+                File dbFile = new File(plugin.getDataFolder(), file);
+                hikariConfig.setDriverClassName("shaded.org.sqlite.JDBC");
+                hikariConfig.setJdbcUrl("jdbc:sqlite:" + dbFile.getAbsolutePath());
+                hikariConfig.setMaximumPoolSize(1);
+            } else {
+                String host = config.getString("host", "localhost");
+                int port = config.getInt("port", 3306);
+                String database = config.getString("database", "minecraft");
+                String username = config.getString("username", "root");
+                String password = config.getString("password", "");
+
+                String url = "jdbc:mariadb://" + host + ":" + port + "/" + database + "?useSSL=false";
+                hikariConfig.setDriverClassName("shaded.org.mariadb.jdbc.Driver");
+                hikariConfig.setJdbcUrl(url);
+                hikariConfig.setUsername(username);
+                hikariConfig.setPassword(password);
+                hikariConfig.setMaximumPoolSize(10);
+                hikariConfig.setLeakDetectionThreshold(10000);
+            }
             hikariConfig.setConnectionTimeout(5000);
-            hikariConfig.setLeakDetectionThreshold(10000);
             dataSource = new HikariDataSource(hikariConfig);
 
             try (Connection conn = dataSource.getConnection();
@@ -59,6 +76,14 @@ public class Database {
     }
 
     private void setupTables(Connection connection) throws SQLException {
+        if (engine == Engine.SQLITE) {
+            setupSQLiteTables(connection);
+        } else {
+            setupMariaTables(connection);
+        }
+    }
+
+    private void setupMariaTables(Connection connection) throws SQLException {
         try (Statement stmt = connection.createStatement()) {
             String chatSql = "CREATE TABLE IF NOT EXISTS chat_log (" +
                     "id INT AUTO_INCREMENT PRIMARY KEY," +
@@ -206,6 +231,161 @@ public class Database {
 
             String analysisSql = "CREATE TABLE IF NOT EXISTS chat_analysis_log (" +
                     "id INT AUTO_INCREMENT PRIMARY KEY," +
+                    "timestamp TIMESTAMP NOT NULL," +
+                    "chatlog TEXT NOT NULL," +
+                    "json TEXT NOT NULL," +
+                    "betroffene_spieler TEXT" +
+                    ")";
+            stmt.executeUpdate(analysisSql);
+        }
+    }
+
+    private void setupSQLiteTables(Connection connection) throws SQLException {
+        try (Statement stmt = connection.createStatement()) {
+            String chatSql = "CREATE TABLE IF NOT EXISTS chat_log (" +
+                    "id INTEGER PRIMARY KEY AUTOINCREMENT," +
+                    "player_uuid TEXT NOT NULL," +
+                    "message_time TIMESTAMP NOT NULL," +
+                    "message TEXT NOT NULL" +
+                    ")";
+            stmt.executeUpdate(chatSql);
+
+            String gptSql = "CREATE TABLE IF NOT EXISTS gpt_log (" +
+                    "id INTEGER PRIMARY KEY AUTOINCREMENT," +
+                    "request_uuid TEXT NOT NULL," +
+                    "player_uuid TEXT," +
+                    "request_time TIMESTAMP NOT NULL," +
+                    "prompt TEXT NOT NULL," +
+                    "response TEXT," +
+                    "response_time TIMESTAMP" +
+                    ")";
+            stmt.executeUpdate(gptSql);
+
+            String cfgSql = "CREATE TABLE IF NOT EXISTS config_params (" +
+                    "id INTEGER PRIMARY KEY AUTOINCREMENT," +
+                    "path TEXT NOT NULL," +
+                    "parameter_path TEXT NOT NULL," +
+                    "min_value INT," +
+                    "max_value INT," +
+                    "recommended_range TEXT," +
+                    "editable BOOLEAN DEFAULT 0," +
+                    "impact_category TEXT," +
+                    "impact_rating INT DEFAULT 5," +
+                    "description TEXT," +
+                    "value_type TEXT DEFAULT 'STRING'," +
+                    "current_value TEXT" +
+                    ")";
+            stmt.executeUpdate(cfgSql);
+
+            String playerSql = "CREATE TABLE IF NOT EXISTS player_registry (" +
+                    "uuid TEXT PRIMARY KEY," +
+                    "alias_id TEXT NOT NULL," +
+                    "reputation_score INT DEFAULT 0," +
+                    "reputation_rank TEXT" +
+                    ")";
+            stmt.executeUpdate(playerSql);
+
+            String eventSql = "CREATE TABLE IF NOT EXISTS reputation_events (" +
+                    "id TEXT PRIMARY KEY," +
+                    "timestamp TIMESTAMP NOT NULL," +
+                    "player_uuid TEXT NOT NULL," +
+                    "change INT NOT NULL," +
+                    "reason_summary TEXT," +
+                    "source_module TEXT," +
+                    "details TEXT" +
+                    ")";
+            stmt.executeUpdate(eventSql);
+
+            String guideSql = "CREATE TABLE IF NOT EXISTS reputation_guidelines (" +
+                    "id INTEGER PRIMARY KEY AUTOINCREMENT," +
+                    "module TEXT NOT NULL," +
+                    "rule TEXT NOT NULL," +
+                    "points INT NOT NULL," +
+                    "description TEXT" +
+                    ")";
+            stmt.executeUpdate(guideSql);
+
+            String flagSql = "CREATE TABLE IF NOT EXISTS chat_reputation_flags (" +
+                    "id INTEGER PRIMARY KEY AUTOINCREMENT," +
+                    "code TEXT NOT NULL," +
+                    "description TEXT," +
+                    "min_change INT NOT NULL," +
+                    "max_change INT NOT NULL," +
+                    "active BOOLEAN DEFAULT 1," +
+                    "last_updated TIMESTAMP NOT NULL" +
+                    ")";
+            stmt.executeUpdate(flagSql);
+
+            String suggestionSql = "CREATE TABLE IF NOT EXISTS suggestions (" +
+                    "id INTEGER PRIMARY KEY AUTOINCREMENT," +
+                    "player_uuid TEXT NOT NULL," +
+                    "parameter_id INT," +
+                    "new_value TEXT," +
+                    "text TEXT," +
+                    "created TIMESTAMP NOT NULL," +
+                    "open BOOLEAN DEFAULT 1," +
+                    "suggestion_type TEXT," +
+                    "gpt_reasoning TEXT," +
+                    "gpt_confidence FLOAT," +
+                    "classified_at TIMESTAMP" +
+                    ")";
+            stmt.executeUpdate(suggestionSql);
+
+            String voteSql = "CREATE TABLE IF NOT EXISTS votes (" +
+                    "id INTEGER PRIMARY KEY AUTOINCREMENT," +
+                    "suggestion_id INT NOT NULL," +
+                    "player_uuid TEXT NOT NULL," +
+                    "vote_yes BOOLEAN NOT NULL," +
+                    "weight DOUBLE NOT NULL" +
+                    ")";
+            stmt.executeUpdate(voteSql);
+
+            String promptSql = "CREATE TABLE IF NOT EXISTS gpt_prompts (" +
+                    "category TEXT PRIMARY KEY," +
+                    "prompt TEXT NOT NULL" +
+                    ")";
+            stmt.executeUpdate(promptSql);
+
+            String responseSql = "CREATE TABLE IF NOT EXISTS gpt_responses (" +
+                    "id INTEGER PRIMARY KEY AUTOINCREMENT," +
+                    "player_uuid TEXT NOT NULL," +
+                    "module TEXT," +
+                    "response TEXT NOT NULL," +
+                    "created TIMESTAMP NOT NULL," +
+                    "delivered BOOLEAN DEFAULT 0" +
+                    ")";
+            stmt.executeUpdate(responseSql);
+
+            String rulesSql = "CREATE TABLE IF NOT EXISTS server_rules (" +
+                    "id INTEGER PRIMARY KEY AUTOINCREMENT," +
+                    "rule_text TEXT NOT NULL," +
+                    "category TEXT" +
+                    ")";
+            stmt.executeUpdate(rulesSql);
+
+            String ruleLogSql = "CREATE TABLE IF NOT EXISTS rule_changes (" +
+                    "id INTEGER PRIMARY KEY AUTOINCREMENT," +
+                    "rule_id INT NOT NULL," +
+                    "old_text TEXT NOT NULL," +
+                    "new_text TEXT NOT NULL," +
+                    "changed_at TIMESTAMP NOT NULL," +
+                    "changed_by TEXT," +
+                    "suggestion_id INT" +
+                    ")";
+            stmt.executeUpdate(ruleLogSql);
+
+            String cfgHistSql = "CREATE TABLE IF NOT EXISTS config_change_history (" +
+                    "change_id TEXT PRIMARY KEY," +
+                    "player_uuid TEXT," +
+                    "param_key TEXT NOT NULL," +
+                    "old_value TEXT," +
+                    "new_value TEXT," +
+                    "changed_at TIMESTAMP NOT NULL" +
+                    ")";
+            stmt.executeUpdate(cfgHistSql);
+
+            String analysisSql = "CREATE TABLE IF NOT EXISTS chat_analysis_log (" +
+                    "id INTEGER PRIMARY KEY AUTOINCREMENT," +
                     "timestamp TIMESTAMP NOT NULL," +
                     "chatlog TEXT NOT NULL," +
                     "json TEXT NOT NULL," +

--- a/src/main/resources/database.yml
+++ b/src/main/resources/database.yml
@@ -1,4 +1,6 @@
 # Datenbankkonfiguration
+engine: sqlite # "sqlite" oder "mariadb"
+file: opencore.db
 host: localhost
 port: 3306
 database: opencore


### PR DESCRIPTION
## Summary
- support MariaDB or SQLite via `engine` in `database.yml`
- default to SQLite and update docs
- include SQLite JDBC driver

## Testing
- `apt-get update -y`
- `apt-get install -y maven`
- `mvn -q -DskipTests install` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:2.6 could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_6845ad3956d083239db5663123828951