### PR TITLE
Add per-command permissions and module checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,25 @@ OpenCore nutzt einen HikariCP-Pool mit zehn Verbindungen. Beim Start wird ein Pi
 
 ## 🧠 Ziel
 Ein Server, der durch Spieler gesteuert, durch GPT unterstützt und durch klare Regeln geschützt wird.
+
+## 🛡 Berechtigungen
+Jeder Befehl besitzt eine eigene Permission:
+
+| Command | Permission |
+|---------|------------|
+| /suggest | `opencore.command.suggest` |
+| /suggestions | `opencore.command.suggestions` |
+| /vote | `opencore.command.vote` |
+| /rules | `opencore.command.rules` |
+| /rollbackconfig | `opencore.command.rollbackconfig` |
+| /myrep | `opencore.command.myrep` |
+| /gptlog | `opencore.command.gptlog` |
+| /repinfo | `opencore.command.repinfo` |
+| /repchange | `opencore.command.repchange` |
+| /status | `opencore.command.status` |
+| /configlist | `opencore.command.configlist` |
+| /votestatus | `opencore.command.votestatus` |
+| /editrule | `opencore.command.editrule` |
+| /rulehistory | `opencore.command.rulehistory` |
+| /chatflags | `opencore.command.chatflags` |
+| /reload | `opencore.command.reload` |

--- a/src/main/java/com/illusioncis7/opencore/OpenCore.java
+++ b/src/main/java/com/illusioncis7/opencore/OpenCore.java
@@ -118,19 +118,18 @@ public class OpenCore extends JavaPlugin {
 
         votingService = new VotingService(this, database, gptService, configService, ruleService, reputationService, planHook);
 
-        if (moduleSuggestions) {
-            SuggestCommand suggestCmd = new SuggestCommand(votingService);
-            Objects.requireNonNull(getCommand("suggest")).setExecutor(suggestCmd);
-            getCommand("suggest").setTabCompleter(suggestCmd);
+        SuggestCommand suggestCmd = new SuggestCommand(votingService);
+        Objects.requireNonNull(getCommand("suggest")).setExecutor(suggestCmd);
+        getCommand("suggest").setTabCompleter(suggestCmd);
 
-            SuggestionsCommand listCmd = new SuggestionsCommand(votingService);
-            Objects.requireNonNull(getCommand("suggestions")).setExecutor(listCmd);
-            getCommand("suggestions").setTabCompleter(listCmd);
+        SuggestionsCommand listCmd = new SuggestionsCommand(votingService);
+        Objects.requireNonNull(getCommand("suggestions")).setExecutor(listCmd);
+        getCommand("suggestions").setTabCompleter(listCmd);
 
-            VoteCommand voteCmd = new VoteCommand(votingService);
-            Objects.requireNonNull(getCommand("vote")).setExecutor(voteCmd);
-            getCommand("vote").setTabCompleter(voteCmd);
-        } else {
+        VoteCommand voteCmd = new VoteCommand(votingService);
+        Objects.requireNonNull(getCommand("vote")).setExecutor(voteCmd);
+        getCommand("vote").setTabCompleter(voteCmd);
+        if (!moduleSuggestions) {
             getLogger().info("Suggestions module disabled via modules.yml");
         }
 
@@ -182,11 +181,9 @@ public class OpenCore extends JavaPlugin {
         Objects.requireNonNull(getCommand("configlist")).setExecutor(cfgListCmd);
         getCommand("configlist").setTabCompleter(cfgListCmd);
 
-        if (moduleSuggestions) {
-            com.illusioncis7.opencore.voting.command.VoteStatusCommand voteStatusCmd = new com.illusioncis7.opencore.voting.command.VoteStatusCommand(votingService);
-            Objects.requireNonNull(getCommand("votestatus")).setExecutor(voteStatusCmd);
-            getCommand("votestatus").setTabCompleter(voteStatusCmd);
-        }
+        com.illusioncis7.opencore.voting.command.VoteStatusCommand voteStatusCmd = new com.illusioncis7.opencore.voting.command.VoteStatusCommand(votingService);
+        Objects.requireNonNull(getCommand("votestatus")).setExecutor(voteStatusCmd);
+        getCommand("votestatus").setTabCompleter(voteStatusCmd);
 
         if (moduleChatAnalyzer) {
             new com.illusioncis7.opencore.reputation.ChatAnalyzerTask(database, gptService, reputationService, chatFlagService, ruleService, getLogger())
@@ -271,5 +268,17 @@ public class OpenCore extends JavaPlugin {
 
     public com.illusioncis7.opencore.setup.SetupManager getSetupManager() {
         return setupManager;
+    }
+
+    public boolean isConfigGrabberEnabled() {
+        return moduleConfigGrabber;
+    }
+
+    public boolean isSuggestionsEnabled() {
+        return moduleSuggestions;
+    }
+
+    public boolean isChatAnalyzerEnabled() {
+        return moduleChatAnalyzer;
     }
 }

--- a/src/main/java/com/illusioncis7/opencore/admin/ReloadCommand.java
+++ b/src/main/java/com/illusioncis7/opencore/admin/ReloadCommand.java
@@ -21,6 +21,10 @@ public class ReloadCommand implements TabExecutor {
 
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!sender.hasPermission("opencore.command.reload")) {
+            plugin.getMessageService().send(sender, "no_permission", null);
+            return true;
+        }
         try {
             plugin.getMessageService().reload();
             ReputationService rep = plugin.getReputationService();

--- a/src/main/java/com/illusioncis7/opencore/admin/StatusCommand.java
+++ b/src/main/java/com/illusioncis7/opencore/admin/StatusCommand.java
@@ -28,6 +28,10 @@ public class StatusCommand implements TabExecutor {
 
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!sender.hasPermission("opencore.command.status")) {
+            OpenCore.getInstance().getMessageService().send(sender, "no_permission", null);
+            return true;
+        }
         int queue = queueManager.getQueueSize();
         int open = votingService.getOpenSuggestions().size();
         long ping = database.ping();

--- a/src/main/java/com/illusioncis7/opencore/config/command/ConfigListCommand.java
+++ b/src/main/java/com/illusioncis7/opencore/config/command/ConfigListCommand.java
@@ -21,6 +21,14 @@ public class ConfigListCommand implements TabExecutor {
 
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!sender.hasPermission("opencore.command.configlist")) {
+            OpenCore.getInstance().getMessageService().send(sender, "no_permission", null);
+            return true;
+        }
+        if (!OpenCore.getInstance().isConfigGrabberEnabled()) {
+            OpenCore.getInstance().getMessageService().send(sender, "module_disabled", null);
+            return true;
+        }
         List<ConfigParameter> list = configService.listParameters();
         if (list.isEmpty()) {
             OpenCore.getInstance().getMessageService().send(sender, "configlist.none", null);

--- a/src/main/java/com/illusioncis7/opencore/config/command/RollbackConfigCommand.java
+++ b/src/main/java/com/illusioncis7/opencore/config/command/RollbackConfigCommand.java
@@ -23,6 +23,14 @@ public class RollbackConfigCommand implements TabExecutor {
 
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!sender.hasPermission("opencore.command.rollbackconfig")) {
+            OpenCore.getInstance().getMessageService().send(sender, "no_permission", null);
+            return true;
+        }
+        if (!OpenCore.getInstance().isConfigGrabberEnabled()) {
+            OpenCore.getInstance().getMessageService().send(sender, "module_disabled", null);
+            return true;
+        }
         if (args.length < 1) {
             OpenCore.getInstance().getMessageService().send(sender, "rollbackconfig.usage", null);
             return true;

--- a/src/main/java/com/illusioncis7/opencore/gpt/command/GptLogCommand.java
+++ b/src/main/java/com/illusioncis7/opencore/gpt/command/GptLogCommand.java
@@ -24,6 +24,10 @@ public class GptLogCommand implements TabExecutor {
 
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!sender.hasPermission("opencore.command.gptlog")) {
+            OpenCore.getInstance().getMessageService().send(sender, "no_permission", null);
+            return true;
+        }
         if (!(sender instanceof Player)) {
             OpenCore.getInstance().getMessageService().send(sender, "gptlog.players_only", null);
             return true;

--- a/src/main/java/com/illusioncis7/opencore/reputation/command/ChatFlagsCommand.java
+++ b/src/main/java/com/illusioncis7/opencore/reputation/command/ChatFlagsCommand.java
@@ -21,6 +21,10 @@ public class ChatFlagsCommand implements TabExecutor {
 
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!sender.hasPermission("opencore.command.chatflags")) {
+            OpenCore.getInstance().getMessageService().send(sender, "no_permission", null);
+            return true;
+        }
         if (args.length == 0 || "list".equalsIgnoreCase(args[0])) {
             List<ReputationFlag> list = service.listFlags();
             if (list.isEmpty()) {
@@ -40,10 +44,6 @@ public class ChatFlagsCommand implements TabExecutor {
             return true;
         }
         if ("set".equalsIgnoreCase(args[0])) {
-            if (!sender.isOp()) {
-                OpenCore.getInstance().getMessageService().send(sender, "reputation.admin_only", null);
-                return true;
-            }
             if (args.length < 4) {
                 OpenCore.getInstance().getMessageService().send(sender, "chatflags.usage_set", null);
                 return true;

--- a/src/main/java/com/illusioncis7/opencore/reputation/command/MyRepCommand.java
+++ b/src/main/java/com/illusioncis7/opencore/reputation/command/MyRepCommand.java
@@ -24,6 +24,10 @@ public class MyRepCommand implements TabExecutor {
 
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!sender.hasPermission("opencore.command.myrep")) {
+            OpenCore.getInstance().getMessageService().send(sender, "no_permission", null);
+            return true;
+        }
         if (!(sender instanceof Player)) {
             OpenCore.getInstance().getMessageService().send(sender, "reputation.players_only", null);
             return true;

--- a/src/main/java/com/illusioncis7/opencore/reputation/command/RepChangeCommand.java
+++ b/src/main/java/com/illusioncis7/opencore/reputation/command/RepChangeCommand.java
@@ -25,8 +25,8 @@ public class RepChangeCommand implements TabExecutor {
 
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
-        if (!sender.isOp()) {
-            OpenCore.getInstance().getMessageService().send(sender, "reputation.admin_only", null);
+        if (!sender.hasPermission("opencore.command.repchange")) {
+            OpenCore.getInstance().getMessageService().send(sender, "no_permission", null);
             return true;
         }
         if (args.length < 1) {

--- a/src/main/java/com/illusioncis7/opencore/reputation/command/RepInfoCommand.java
+++ b/src/main/java/com/illusioncis7/opencore/reputation/command/RepInfoCommand.java
@@ -25,8 +25,8 @@ public class RepInfoCommand implements TabExecutor {
 
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
-        if (!sender.isOp()) {
-            OpenCore.getInstance().getMessageService().send(sender, "reputation.admin_only", null);
+        if (!sender.hasPermission("opencore.command.repinfo")) {
+            OpenCore.getInstance().getMessageService().send(sender, "no_permission", null);
             return true;
         }
         if (args.length < 1) {

--- a/src/main/java/com/illusioncis7/opencore/rules/command/EditRuleCommand.java
+++ b/src/main/java/com/illusioncis7/opencore/rules/command/EditRuleCommand.java
@@ -23,6 +23,10 @@ public class EditRuleCommand implements TabExecutor {
 
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!sender.hasPermission("opencore.command.editrule")) {
+            OpenCore.getInstance().getMessageService().send(sender, "no_permission", null);
+            return true;
+        }
         if (args.length < 2) {
             OpenCore.getInstance().getMessageService().send(sender, "editrule.usage", null);
             return true;

--- a/src/main/java/com/illusioncis7/opencore/rules/command/RuleHistoryCommand.java
+++ b/src/main/java/com/illusioncis7/opencore/rules/command/RuleHistoryCommand.java
@@ -23,6 +23,10 @@ public class RuleHistoryCommand implements TabExecutor {
 
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!sender.hasPermission("opencore.command.rulehistory")) {
+            OpenCore.getInstance().getMessageService().send(sender, "no_permission", null);
+            return true;
+        }
         if (args.length < 1) {
             OpenCore.getInstance().getMessageService().send(sender, "rulehistory.usage", null);
             return true;

--- a/src/main/java/com/illusioncis7/opencore/rules/command/RulesCommand.java
+++ b/src/main/java/com/illusioncis7/opencore/rules/command/RulesCommand.java
@@ -21,6 +21,10 @@ public class RulesCommand implements TabExecutor {
 
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!sender.hasPermission("opencore.command.rules")) {
+            OpenCore.getInstance().getMessageService().send(sender, "no_permission", null);
+            return true;
+        }
         if (args.length >= 2 && args[0].equalsIgnoreCase("id")) {
             try {
                 int id = Integer.parseInt(args[1]);

--- a/src/main/java/com/illusioncis7/opencore/voting/command/SuggestCommand.java
+++ b/src/main/java/com/illusioncis7/opencore/voting/command/SuggestCommand.java
@@ -23,6 +23,14 @@ public class SuggestCommand implements TabExecutor {
 
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!sender.hasPermission("opencore.command.suggest")) {
+            OpenCore.getInstance().getMessageService().send(sender, "no_permission", null);
+            return true;
+        }
+        if (!OpenCore.getInstance().isSuggestionsEnabled()) {
+            OpenCore.getInstance().getMessageService().send(sender, "module_disabled", null);
+            return true;
+        }
         if (!(sender instanceof Player)) {
             OpenCore.getInstance().getMessageService().send(sender, "suggest.players_only", null);
             return true;

--- a/src/main/java/com/illusioncis7/opencore/voting/command/SuggestionsCommand.java
+++ b/src/main/java/com/illusioncis7/opencore/voting/command/SuggestionsCommand.java
@@ -25,6 +25,14 @@ public class SuggestionsCommand implements TabExecutor {
 
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!sender.hasPermission("opencore.command.suggestions")) {
+            OpenCore.getInstance().getMessageService().send(sender, "no_permission", null);
+            return true;
+        }
+        if (!OpenCore.getInstance().isSuggestionsEnabled()) {
+            OpenCore.getInstance().getMessageService().send(sender, "module_disabled", null);
+            return true;
+        }
         int page = 1;
         if (args.length > 0) {
             try { page = Integer.parseInt(args[0]); } catch (NumberFormatException ignore) {}

--- a/src/main/java/com/illusioncis7/opencore/voting/command/VoteCommand.java
+++ b/src/main/java/com/illusioncis7/opencore/voting/command/VoteCommand.java
@@ -21,6 +21,14 @@ public class VoteCommand implements TabExecutor {
 
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!sender.hasPermission("opencore.command.vote")) {
+            OpenCore.getInstance().getMessageService().send(sender, "no_permission", null);
+            return true;
+        }
+        if (!OpenCore.getInstance().isSuggestionsEnabled()) {
+            OpenCore.getInstance().getMessageService().send(sender, "module_disabled", null);
+            return true;
+        }
         if (!(sender instanceof Player)) {
             OpenCore.getInstance().getMessageService().send(sender, "vote.players_only", null);
             return true;

--- a/src/main/java/com/illusioncis7/opencore/voting/command/VoteStatusCommand.java
+++ b/src/main/java/com/illusioncis7/opencore/voting/command/VoteStatusCommand.java
@@ -21,6 +21,14 @@ public class VoteStatusCommand implements TabExecutor {
 
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!sender.hasPermission("opencore.command.votestatus")) {
+            OpenCore.getInstance().getMessageService().send(sender, "no_permission", null);
+            return true;
+        }
+        if (!OpenCore.getInstance().isSuggestionsEnabled()) {
+            OpenCore.getInstance().getMessageService().send(sender, "module_disabled", null);
+            return true;
+        }
         List<Suggestion> list = votingService.getClosedSuggestions();
         if (list.isEmpty()) {
             OpenCore.getInstance().getMessageService().send(sender, "votestatus.none", null);

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -110,3 +110,6 @@ join:
   privacy_warning:
     - "&cBitte teile keine sensiblen Daten im \u00F6ffentlichen Chat."
     - "&7Der Chat wird im Discord angezeigt und vom Plugin ausgewertet."
+
+no_permission: "&cDazu hast du keine Berechtigung."
+module_disabled: "&cDieses Modul ist deaktiviert."

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -6,33 +6,49 @@ softdepend: [Plan]
 commands:
   suggest:
     description: Submit a configuration suggestion
+    permission: opencore.command.suggest
   suggestions:
     description: List open suggestions
+    permission: opencore.command.suggestions
   vote:
     description: Vote on a suggestion
+    permission: opencore.command.vote
   rules:
     description: List server rules
+    permission: opencore.command.rules
   rollbackconfig:
     description: Roll back a configuration change
+    permission: opencore.command.rollbackconfig
   myrep:
     description: Show your reputation
+    permission: opencore.command.myrep
   gptlog:
     description: Show recent GPT responses
+    permission: opencore.command.gptlog
   repinfo:
     description: Show reputation info for a player
+    permission: opencore.command.repinfo
   repchange:
     description: Show details for a reputation change event
+    permission: opencore.command.repchange
   status:
     description: Show plugin status
+    permission: opencore.command.status
   configlist:
     description: List configurable parameters
+    permission: opencore.command.configlist
   votestatus:
     description: Show closed vote results
+    permission: opencore.command.votestatus
   editrule:
     description: Edit an existing rule
+    permission: opencore.command.editrule
   rulehistory:
     description: Show history for a rule
+    permission: opencore.command.rulehistory
   chatflags:
     description: Manage chat reputation flags
+    permission: opencore.command.chatflags
   reload:
     description: Reload plugin configuration
+    permission: opencore.command.reload


### PR DESCRIPTION
## Summary
- add permission nodes to plugin.yml
- introduce module check methods in `OpenCore`
- enforce permissions and module status in all commands
- log when suggestion module disabled
- document permissions in README
- new messages `no_permission` and `module_disabled`

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845ae8578e083239ec33dd4dca63830