### PR TITLE
Fix SQLite driver shading

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,10 +44,6 @@
                                     <pattern>org.mariadb</pattern>
                                     <shadedPattern>shaded.org.mariadb</shadedPattern>
                                 </relocation>
-                                <relocation>
-                                    <pattern>org.sqlite</pattern>
-                                    <shadedPattern>shaded.org.sqlite</shadedPattern>
-                                </relocation>
                             </relocations>
                         </configuration>
                     </execution>

--- a/src/main/java/com/illusioncis7/opencore/database/Database.java
+++ b/src/main/java/com/illusioncis7/opencore/database/Database.java
@@ -41,7 +41,7 @@ public class Database {
             if (engine == Engine.SQLITE) {
                 String file = config.getString("file", "opencore.db");
                 File dbFile = new File(plugin.getDataFolder(), file);
-                hikariConfig.setDriverClassName("shaded.org.sqlite.JDBC");
+                hikariConfig.setDriverClassName("org.sqlite.JDBC");
                 hikariConfig.setJdbcUrl("jdbc:sqlite:" + dbFile.getAbsolutePath());
                 hikariConfig.setMaximumPoolSize(1);
             } else {


### PR DESCRIPTION
## Summary
- remove package relocation for SQLite in the Maven shade plugin
- use original `org.sqlite.JDBC` driver class

## Testing
- `mvn test` *(fails: PluginResolutionException, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6845b2b0e4648323a420ac819bd1ff9f