### PR TITLE
Fix database code for SQLite compatibility

### DIFF
--- a/src/main/java/com/illusioncis7/opencore/config/ConfigService.java
+++ b/src/main/java/com/illusioncis7/opencore/config/ConfigService.java
@@ -123,8 +123,16 @@ public class ConfigService {
             return;
         }
 
-        String sql = "INSERT INTO config_params (path, parameter_path, description, value_type, current_value) VALUES (?, ?, ?, ?, ?) " +
-                "ON DUPLICATE KEY UPDATE path = VALUES(path), current_value = VALUES(current_value), description = VALUES(description)";
+        String sql;
+        if (database.isSQLite()) {
+            sql = "INSERT INTO config_params (path, parameter_path, description, value_type, current_value) " +
+                    "VALUES (?, ?, ?, ?, ?) " +
+                    "ON CONFLICT(path, parameter_path) DO UPDATE SET " +
+                    "current_value=excluded.current_value, description=excluded.description";
+        } else {
+            sql = "INSERT INTO config_params (path, parameter_path, description, value_type, current_value) VALUES (?, ?, ?, ?, ?) " +
+                    "ON DUPLICATE KEY UPDATE path = VALUES(path), current_value = VALUES(current_value), description = VALUES(description)";
+        }
 
         try (Connection conn = database.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql)) {

--- a/src/main/java/com/illusioncis7/opencore/database/Database.java
+++ b/src/main/java/com/illusioncis7/opencore/database/Database.java
@@ -273,7 +273,8 @@ public class Database {
                     "impact_rating INT DEFAULT 5," +
                     "description TEXT," +
                     "value_type TEXT DEFAULT 'STRING'," +
-                    "current_value TEXT" +
+                    "current_value TEXT," +
+                    "UNIQUE(path, parameter_path)" +
                     ")";
             stmt.executeUpdate(cfgSql);
 
@@ -336,7 +337,8 @@ public class Database {
                     "suggestion_id INT NOT NULL," +
                     "player_uuid TEXT NOT NULL," +
                     "vote_yes BOOLEAN NOT NULL," +
-                    "weight DOUBLE NOT NULL" +
+                    "weight DOUBLE NOT NULL," +
+                    "UNIQUE(suggestion_id, player_uuid)" +
                     ")";
             stmt.executeUpdate(voteSql);
 
@@ -407,6 +409,20 @@ public class Database {
 
     public boolean isConnected() {
         return dataSource != null && !dataSource.isClosed();
+    }
+
+    /**
+     * @return true if the underlying database engine is SQLite.
+     */
+    public boolean isSQLite() {
+        return engine == Engine.SQLITE;
+    }
+
+    /**
+     * @return true if the underlying database engine is MariaDB.
+     */
+    public boolean isMariaDB() {
+        return engine == Engine.MARIADB;
     }
 
     public String getPrompt(String category) {

--- a/src/main/java/com/illusioncis7/opencore/gpt/PolicyService.java
+++ b/src/main/java/com/illusioncis7/opencore/gpt/PolicyService.java
@@ -24,14 +24,26 @@ public class PolicyService {
 
     private void initTable() {
         if (!database.isConnected()) return;
-        String sql = "CREATE TABLE IF NOT EXISTS gpt_policies (" +
-                "id INT AUTO_INCREMENT PRIMARY KEY," +
-                "name VARCHAR(50) NOT NULL," +
-                "policy_text TEXT NOT NULL," +
-                "version INT NOT NULL," +
-                "active BOOLEAN DEFAULT 1," +
-                "last_updated TIMESTAMP NOT NULL" +
-                ")";
+        String sql;
+        if (database.isSQLite()) {
+            sql = "CREATE TABLE IF NOT EXISTS gpt_policies (" +
+                    "id INTEGER PRIMARY KEY AUTOINCREMENT," +
+                    "name TEXT NOT NULL," +
+                    "policy_text TEXT NOT NULL," +
+                    "version INT NOT NULL," +
+                    "active BOOLEAN DEFAULT 1," +
+                    "last_updated TIMESTAMP NOT NULL" +
+                    ")";
+        } else {
+            sql = "CREATE TABLE IF NOT EXISTS gpt_policies (" +
+                    "id INT AUTO_INCREMENT PRIMARY KEY," +
+                    "name VARCHAR(50) NOT NULL," +
+                    "policy_text TEXT NOT NULL," +
+                    "version INT NOT NULL," +
+                    "active BOOLEAN DEFAULT 1," +
+                    "last_updated TIMESTAMP NOT NULL" +
+                    ")";
+        }
         try (Connection conn = database.getConnection();
              Statement stmt = conn.createStatement()) {
             stmt.executeUpdate(sql);

--- a/src/main/java/com/illusioncis7/opencore/reputation/ChatReputationFlagService.java
+++ b/src/main/java/com/illusioncis7/opencore/reputation/ChatReputationFlagService.java
@@ -28,15 +28,28 @@ public class ChatReputationFlagService {
 
     private void initTable() {
         if (!database.isConnected()) return;
-        String sql = "CREATE TABLE IF NOT EXISTS chat_reputation_flags (" +
-                "id INT AUTO_INCREMENT PRIMARY KEY," +
-                "code VARCHAR(50) NOT NULL," +
-                "description TEXT," +
-                "min_change INT NOT NULL," +
-                "max_change INT NOT NULL," +
-                "active BOOLEAN DEFAULT 1," +
-                "last_updated TIMESTAMP NOT NULL" +
-                ")";
+        String sql;
+        if (database.isSQLite()) {
+            sql = "CREATE TABLE IF NOT EXISTS chat_reputation_flags (" +
+                    "id INTEGER PRIMARY KEY AUTOINCREMENT," +
+                    "code TEXT NOT NULL," +
+                    "description TEXT," +
+                    "min_change INT NOT NULL," +
+                    "max_change INT NOT NULL," +
+                    "active BOOLEAN DEFAULT 1," +
+                    "last_updated TIMESTAMP NOT NULL" +
+                    ")";
+        } else {
+            sql = "CREATE TABLE IF NOT EXISTS chat_reputation_flags (" +
+                    "id INT AUTO_INCREMENT PRIMARY KEY," +
+                    "code VARCHAR(50) NOT NULL," +
+                    "description TEXT," +
+                    "min_change INT NOT NULL," +
+                    "max_change INT NOT NULL," +
+                    "active BOOLEAN DEFAULT 1," +
+                    "last_updated TIMESTAMP NOT NULL" +
+                    ")";
+        }
         try (Connection conn = database.getConnection();
              Statement stmt = conn.createStatement()) {
             stmt.executeUpdate(sql);

--- a/src/main/java/com/illusioncis7/opencore/voting/VotingService.java
+++ b/src/main/java/com/illusioncis7/opencore/voting/VotingService.java
@@ -471,8 +471,15 @@ public class VotingService {
         if (weight <= 0.0) {
             return false;
         }
-        String sql = "INSERT INTO votes (suggestion_id, player_uuid, vote_yes, weight) VALUES (?, ?, ?, ?) " +
-                "ON DUPLICATE KEY UPDATE vote_yes = VALUES(vote_yes), weight = VALUES(weight)";
+        String sql;
+        if (database.isSQLite()) {
+            sql = "INSERT INTO votes (suggestion_id, player_uuid, vote_yes, weight) VALUES (?, ?, ?, ?) " +
+                    "ON CONFLICT(suggestion_id, player_uuid) DO UPDATE SET " +
+                    "vote_yes=excluded.vote_yes, weight=excluded.weight";
+        } else {
+            sql = "INSERT INTO votes (suggestion_id, player_uuid, vote_yes, weight) VALUES (?, ?, ?, ?) " +
+                    "ON DUPLICATE KEY UPDATE vote_yes = VALUES(vote_yes), weight = VALUES(weight)";
+        }
         try (Connection conn = database.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql)) {
             ps.setInt(1, suggestionId);


### PR DESCRIPTION
## Summary
- add helpers to detect which database engine is used
- create SQLite tables with proper UNIQUE constraints
- adjust initialization SQL for SQLite in `ChatReputationFlagService` and `PolicyService`
- use `ON CONFLICT` upserts for SQLite in `ConfigService` and `VotingService`

## Testing
- `mvn -q -DskipTests=false test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845bcacad108323af8ddd63e6a31795