### PR TITLE
Add SQL import command

### DIFF
--- a/src/main/java/com/illusioncis7/opencore/OpenCore.java
+++ b/src/main/java/com/illusioncis7/opencore/OpenCore.java
@@ -177,6 +177,10 @@ public class OpenCore extends JavaPlugin {
         Objects.requireNonNull(getCommand("status")).setExecutor(statusCmd);
         getCommand("status").setTabCompleter(statusCmd);
 
+        com.illusioncis7.opencore.admin.ImportSqlCommand importSqlCmd = new com.illusioncis7.opencore.admin.ImportSqlCommand(database);
+        Objects.requireNonNull(getCommand("importsql")).setExecutor(importSqlCmd);
+        getCommand("importsql").setTabCompleter(importSqlCmd);
+
         com.illusioncis7.opencore.config.command.ConfigListCommand cfgListCmd = new com.illusioncis7.opencore.config.command.ConfigListCommand(configService);
         Objects.requireNonNull(getCommand("configlist")).setExecutor(cfgListCmd);
         getCommand("configlist").setTabCompleter(cfgListCmd);

--- a/src/main/java/com/illusioncis7/opencore/admin/ImportSqlCommand.java
+++ b/src/main/java/com/illusioncis7/opencore/admin/ImportSqlCommand.java
@@ -1,0 +1,51 @@
+package com.illusioncis7.opencore.admin;
+
+import com.illusioncis7.opencore.OpenCore;
+import com.illusioncis7.opencore.database.Database;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabExecutor;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Imports SQL statements from a file into the active database.
+ * The file must be located inside the plugin folder.
+ */
+public class ImportSqlCommand implements TabExecutor {
+
+    private final Database database;
+
+    public ImportSqlCommand(Database database) {
+        this.database = database;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!sender.hasPermission("opencore.command.importsql")) {
+            OpenCore.getInstance().getMessageService().send(sender, "no_permission", null);
+            return true;
+        }
+        if (args.length != 1) {
+            OpenCore.getInstance().getMessageService().send(sender, "importsql.usage", null);
+            return true;
+        }
+
+        File file = new File(OpenCore.getInstance().getDataFolder(), args[0]);
+        boolean result = database.executeSqlFile(file);
+        if (result) {
+            OpenCore.getInstance().getMessageService().send(sender, "importsql.success", null);
+        } else {
+            OpenCore.getInstance().getMessageService().send(sender, "importsql.failed", null);
+        }
+        return true;
+    }
+
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+        return Collections.emptyList();
+    }
+}
+

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -101,6 +101,10 @@ gptlog:
 reload:
   success: "&aKonfiguration neu geladen."
   failed: "&cReload fehlgeschlagen."
+importsql:
+  usage: "&cVerwendung: /importsql <file.sql>"
+  success: "&aSQL-Datei importiert."
+  failed: "&cImport fehlgeschlagen."
 
 response:
   module: "&e[{module}] {text}"

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -52,3 +52,6 @@ commands:
   reload:
     description: Reload plugin configuration
     permission: opencore.command.reload
+  importsql:
+    description: Import an SQL dump into the database
+    permission: opencore.command.importsql


### PR DESCRIPTION
## Summary
- add ImportSqlCommand for admins to import SQL dumps into SQLite
- execute SQL file with new Database#executeSqlFile helper
- wire command into OpenCore and plugin.yml
- add messages for new command

## Testing
- `mvn -q test` *(fails: PluginResolutionException - network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6845c44eb54c8323b6f51d39cea50033