### PR TITLE
Increase pool size and inline alias query

### DIFF
--- a/src/main/java/com/illusioncis7/opencore/database/Database.java
+++ b/src/main/java/com/illusioncis7/opencore/database/Database.java
@@ -43,7 +43,8 @@ public class Database {
                 File dbFile = new File(plugin.getDataFolder(), file);
                 hikariConfig.setDriverClassName("org.sqlite.JDBC");
                 hikariConfig.setJdbcUrl("jdbc:sqlite:" + dbFile.getAbsolutePath());
-                hikariConfig.setMaximumPoolSize(1);
+                // allow a second connection so tasks can reuse the pool
+                hikariConfig.setMaximumPoolSize(2);
             } else {
                 String host = config.getString("host", "localhost");
                 int port = config.getInt("port", 3306);

--- a/src/main/java/com/illusioncis7/opencore/reputation/ChatAnalyzerTask.java
+++ b/src/main/java/com/illusioncis7/opencore/reputation/ChatAnalyzerTask.java
@@ -154,7 +154,9 @@ public class ChatAnalyzerTask extends BukkitRunnable {
         if (!database.isConnected()) {
             return list;
         }
-        String sql = "SELECT id, player_uuid, message, message_time FROM chat_log WHERE message_time > ?";
+        String sql = "SELECT c.id, c.player_uuid, p.alias_id, c.message, c.message_time " +
+                     "FROM chat_log c LEFT JOIN player_registry p ON c.player_uuid = p.uuid " +
+                     "WHERE c.message_time > ?";
         try (Connection conn = database.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql)) {
             ps.setTimestamp(1, Timestamp.from(since));
@@ -162,9 +164,9 @@ public class ChatAnalyzerTask extends BukkitRunnable {
                 while (rs.next()) {
                     long id = rs.getLong(1);
                     UUID player = UUID.fromString(rs.getString(2));
-                    String message = rs.getString(3);
-                    Timestamp time = rs.getTimestamp(4);
-                    String alias = getAlias(player);
+                    String alias = rs.getString(3);
+                    String message = rs.getString(4);
+                    Timestamp time = rs.getTimestamp(5);
                     list.add(new ChatMessage(id, player, alias, message, time.toInstant()));
                 }
             }


### PR DESCRIPTION
## Summary
- allow two SQLite connections so async tasks don't block each other
- join alias lookup directly in ChatAnalyzerTask query to reuse one connection

## Testing
- `mvn -q test` *(fails: Could not transfer artifact maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_6845c65370288323b247d3d9e1cd5d64