### PR TITLE
Configurable chat analysis interval

### DIFF
--- a/src/main/java/com/illusioncis7/opencore/admin/ReloadCommand.java
+++ b/src/main/java/com/illusioncis7/opencore/admin/ReloadCommand.java
@@ -31,6 +31,7 @@ public class ReloadCommand implements TabExecutor {
             if (rep != null) {
                 rep.reload();
             }
+            plugin.reloadChatAnalyzer();
             plugin.getMessageService().send(sender, "reload.success", null);
         } catch (Exception e) {
             plugin.getLogger().warning("Failed to reload: " + e.getMessage());

--- a/src/main/java/com/illusioncis7/opencore/reputation/ReputationService.java
+++ b/src/main/java/com/illusioncis7/opencore/reputation/ReputationService.java
@@ -23,6 +23,7 @@ public class ReputationService {
     private int minScore = -500;
     private int maxScore = 500;
     private int maxGainPerAnalysis = 10;
+    private int analysisIntervalMinutes = 30;
 
     private static class Range {
         final int min;
@@ -58,6 +59,7 @@ public class ReputationService {
             minScore = rep.getInt("min-score", -500);
             maxScore = rep.getInt("max-score", 500);
             maxGainPerAnalysis = rep.getInt("maxReputationPerAnalysis", 10);
+            analysisIntervalMinutes = rep.getInt("analysis-interval-minutes", 30);
             ConfigurationSection changes = rep.getConfigurationSection("changes");
             if (changes != null) {
                 for (String key : changes.getKeys(false)) {
@@ -88,6 +90,10 @@ public class ReputationService {
 
     public int getMaxGainPerAnalysis() {
         return maxGainPerAnalysis;
+    }
+
+    public int getAnalysisIntervalMinutes() {
+        return analysisIntervalMinutes;
     }
 
     public boolean hasRange(String key) {

--- a/src/main/java/com/illusioncis7/opencore/reputation/command/ChatAnalyzeCommand.java
+++ b/src/main/java/com/illusioncis7/opencore/reputation/command/ChatAnalyzeCommand.java
@@ -1,0 +1,38 @@
+package com.illusioncis7.opencore.reputation.command;
+
+import com.illusioncis7.opencore.OpenCore;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabExecutor;
+
+import java.util.Collections;
+import java.util.List;
+
+/** Command to trigger an immediate chat analysis. */
+public class ChatAnalyzeCommand implements TabExecutor {
+    private final OpenCore plugin;
+
+    public ChatAnalyzeCommand(OpenCore plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!sender.hasPermission("opencore.command.chatanalyze")) {
+            plugin.getMessageService().send(sender, "no_permission", null);
+            return true;
+        }
+        if (!plugin.isChatAnalyzerEnabled()) {
+            plugin.getMessageService().send(sender, "module_disabled", null);
+            return true;
+        }
+        plugin.runChatAnalysisNow();
+        plugin.getMessageService().send(sender, "chatanalyze.started", null);
+        return true;
+    }
+
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+        return Collections.emptyList();
+    }
+}

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -115,5 +115,7 @@ join:
     - "&cBitte teile keine sensiblen Daten im \u00F6ffentlichen Chat."
     - "&7Der Chat wird im Discord angezeigt und vom Plugin ausgewertet."
 
-no_permission: "&cDazu hast du keine Berechtigung."
-module_disabled: "&cDieses Modul ist deaktiviert."
+  no_permission: "&cDazu hast du keine Berechtigung."
+  module_disabled: "&cDieses Modul ist deaktiviert."
+chatanalyze:
+  started: "&aChat-Analyse wird ausgef\u00FChrt."

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -55,3 +55,6 @@ commands:
   importsql:
     description: Import an SQL dump into the database
     permission: opencore.command.importsql
+  chatanalyze:
+    description: Run chat analysis immediately
+    permission: opencore.command.chatanalyze

--- a/src/main/resources/reputation.yml
+++ b/src/main/resources/reputation.yml
@@ -2,6 +2,7 @@ reputation:
   min-score: -500
   max-score: 500
   maxReputationPerAnalysis: 10
+  analysis-interval-minutes: 30
   changes:
     helpful-answer:
       min: 2


### PR DESCRIPTION
## Summary
- add `analysis-interval-minutes` to reputation config
- support new interval in `ReputationService`
- manage and restart `ChatAnalyzerTask` in `OpenCore`
- new `/chatanalyze` command to run analysis immediately
- reload command now restarts analyzer
- document new command in plugin.yml and messages.yml

## Testing
- `mvn -q -DskipTests package` *(fails: PluginResolutionException)*

------
https://chatgpt.com/codex/tasks/task_e_6846863cb72083238db28213d263c99b