### PR TITLE
Add centralized command with alias support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Jeder Befehl besitzt eine eigene Permission:
 
 | Command | Permission |
 |---------|------------|
+| /opencore (alias /oc) | `opencore.command.opencore` |
 | /suggest | `opencore.command.suggest` |
 | /suggestions | `opencore.command.suggestions` |
 | /vote | `opencore.command.vote` |
@@ -57,3 +58,5 @@ Jeder Befehl besitzt eine eigene Permission:
 | /rulehistory | `opencore.command.rulehistory` |
 | /chatflags | `opencore.command.chatflags` |
 | /reload | `opencore.command.reload` |
+
+Alle Befehle lassen sich auch als Unterbefehle von `/opencore` bzw. `/oc` ausführen. Die deutschen Aliase sind in `command-aliases.yml` definiert und können angepasst werden.

--- a/src/main/java/com/illusioncis7/opencore/OpenCore.java
+++ b/src/main/java/com/illusioncis7/opencore/OpenCore.java
@@ -45,6 +45,7 @@ public class OpenCore extends JavaPlugin {
     private VotingService votingService;
     private PlanHook planHook;
     private MessageService messageService;
+    private com.illusioncis7.opencore.command.OpenCoreCommand coreCommand;
     private com.illusioncis7.opencore.api.ApiServer apiServer;
     private com.illusioncis7.opencore.setup.SetupManager setupManager;
     private com.illusioncis7.opencore.reputation.ChatAnalyzerTask chatAnalyzerTask;
@@ -196,6 +197,29 @@ public class OpenCore extends JavaPlugin {
         Objects.requireNonNull(getCommand("votestatus")).setExecutor(voteStatusCmd);
         getCommand("votestatus").setTabCompleter(voteStatusCmd);
 
+        coreCommand = new com.illusioncis7.opencore.command.OpenCoreCommand(this, messageService);
+        coreCommand.register("suggest", suggestCmd);
+        coreCommand.register("suggestions", listCmd);
+        coreCommand.register("vote", voteCmd);
+        coreCommand.register("rules", rulesCmd);
+        coreCommand.register("rollbackconfig", rollCmd);
+        coreCommand.register("myrep", myRepCmd);
+        coreCommand.register("gptlog", gptLogCmd);
+        coreCommand.register("repinfo", repInfoCmd);
+        coreCommand.register("repchange", repChangeCmd);
+        coreCommand.register("status", statusCmd);
+        coreCommand.register("configlist", cfgListCmd);
+        coreCommand.register("votestatus", voteStatusCmd);
+        coreCommand.register("editrule", editRuleCmd);
+        coreCommand.register("rulehistory", ruleHistCmd);
+        coreCommand.register("chatflags", chatFlagsCmd);
+        coreCommand.register("reload", reloadCmd);
+        coreCommand.register("importsql", importSqlCmd);
+        coreCommand.register("chatanalyze", chatAnalyzeCmd);
+
+        Objects.requireNonNull(getCommand("opencore")).setExecutor(coreCommand);
+        getCommand("opencore").setTabCompleter(coreCommand);
+
         if (moduleChatAnalyzer) {
             startChatAnalyzer();
         } else {
@@ -274,6 +298,10 @@ public class OpenCore extends JavaPlugin {
 
     public MessageService getMessageService() {
         return messageService;
+    }
+
+    public com.illusioncis7.opencore.command.OpenCoreCommand getCoreCommand() {
+        return coreCommand;
     }
 
     /** Start the periodic chat analyzer using the configured interval. */

--- a/src/main/java/com/illusioncis7/opencore/admin/ReloadCommand.java
+++ b/src/main/java/com/illusioncis7/opencore/admin/ReloadCommand.java
@@ -31,6 +31,7 @@ public class ReloadCommand implements TabExecutor {
             if (rep != null) {
                 rep.reload();
             }
+            OpenCore.getInstance().getCoreCommand().loadAliases();
             plugin.reloadChatAnalyzer();
             plugin.getMessageService().send(sender, "reload.success", null);
         } catch (Exception e) {

--- a/src/main/java/com/illusioncis7/opencore/command/OpenCoreCommand.java
+++ b/src/main/java/com/illusioncis7/opencore/command/OpenCoreCommand.java
@@ -1,0 +1,99 @@
+package com.illusioncis7.opencore.command;
+
+import com.illusioncis7.opencore.OpenCore;
+import com.illusioncis7.opencore.message.MessageService;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabExecutor;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.io.File;
+import java.util.*;
+
+/**
+ * Root command that dispatches subcommands and supports configurable aliases.
+ */
+public class OpenCoreCommand implements TabExecutor {
+    private final JavaPlugin plugin;
+    private final MessageService messages;
+    private final Map<String, TabExecutor> executors = new HashMap<>();
+    private final Map<String, String> aliasMap = new HashMap<>();
+
+    public OpenCoreCommand(JavaPlugin plugin, MessageService messages) {
+        this.plugin = plugin;
+        this.messages = messages;
+        loadAliases();
+    }
+
+    /** Reload alias configuration from command-aliases.yml. */
+    public void loadAliases() {
+        aliasMap.clear();
+        File file = new File(plugin.getDataFolder(), "command-aliases.yml");
+        if (!file.exists()) {
+            plugin.saveResource("command-aliases.yml", false);
+        }
+        FileConfiguration cfg = YamlConfiguration.loadConfiguration(file);
+        ConfigurationSection sec = cfg.getConfigurationSection("aliases");
+        if (sec != null) {
+            for (String key : sec.getKeys(false)) {
+                List<String> aliases = sec.getStringList(key);
+                for (String a : aliases) {
+                    aliasMap.put(a.toLowerCase(Locale.ROOT), key.toLowerCase(Locale.ROOT));
+                }
+            }
+        }
+    }
+
+    public void register(String name, TabExecutor exec) {
+        executors.put(name.toLowerCase(Locale.ROOT), exec);
+    }
+
+    private String map(String input) {
+        return aliasMap.getOrDefault(input.toLowerCase(Locale.ROOT), input.toLowerCase(Locale.ROOT));
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (args.length == 0) {
+            messages.send(sender, "core.usage", null);
+            return true;
+        }
+        String sub = map(args[0]);
+        TabExecutor exec = executors.get(sub);
+        if (exec == null) {
+            Map<String, String> ph = Collections.singletonMap("sub", args[0]);
+            messages.send(sender, "core.unknown", ph);
+            return true;
+        }
+        String[] newArgs = Arrays.copyOfRange(args, 1, args.length);
+        return exec.onCommand(sender, command, sub, newArgs);
+    }
+
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+        if (args.length == 1) {
+            Set<String> opts = new HashSet<>();
+            opts.addAll(executors.keySet());
+            opts.addAll(aliasMap.keySet());
+            List<String> res = new ArrayList<>();
+            for (String o : opts) {
+                if (o.startsWith(args[0].toLowerCase(Locale.ROOT))) {
+                    res.add(o);
+                }
+            }
+            Collections.sort(res);
+            return res;
+        } else if (args.length > 1) {
+            String sub = map(args[0]);
+            TabExecutor exec = executors.get(sub);
+            if (exec != null) {
+                String[] newArgs = Arrays.copyOfRange(args, 1, args.length);
+                return exec.onTabComplete(sender, command, sub, newArgs);
+            }
+        }
+        return Collections.emptyList();
+    }
+}

--- a/src/main/resources/command-aliases.yml
+++ b/src/main/resources/command-aliases.yml
@@ -1,0 +1,37 @@
+aliases:
+  suggest:
+    - vorschlag
+  suggestions:
+    - vorschlaege
+  vote:
+    - abstimmen
+  rules:
+    - regeln
+  rollbackconfig:
+    - rollback
+  myrep:
+    - ruf
+  gptlog:
+    - gptlog
+  repinfo:
+    - repinfo
+  repchange:
+    - repaenderung
+  status:
+    - status
+  configlist:
+    - configliste
+  votestatus:
+    - abstimmstatus
+  editrule:
+    - regelbearbeiten
+  rulehistory:
+    - regelverlauf
+  chatflags:
+    - chatflags
+  reload:
+    - neuladen
+  importsql:
+    - importsql
+  chatanalyze:
+    - chatanalyse

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -110,6 +110,10 @@ response:
   module: "&e[{module}] {text}"
   plain: "{text}"
 
+core:
+  usage: "&cVerwendung: /oc <Befehl>"
+  unknown: "&cUnbekannter Unterbefehl: {sub}"
+
 join:
   privacy_warning:
     - "&cBitte teile keine sensiblen Daten im \u00F6ffentlichen Chat."

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -4,6 +4,10 @@ main: com.illusioncis7.opencore.OpenCore
 api-version: 1.21
 softdepend: [Plan]
 commands:
+  opencore:
+    description: Root command for OpenCore
+    aliases: [oc]
+    permission: opencore.command.opencore
   suggest:
     description: Submit a configuration suggestion
     permission: opencore.command.suggest


### PR DESCRIPTION
## Summary
- introduce `OpenCoreCommand` to handle `/opencore` (alias `/oc`)
- load subcommand aliases from `command-aliases.yml`
- wire new root command in plugin
- reload aliases on `/reload`
- document new command usage and alias configuration

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846947d9efc83238b464968df4c52cb