### PR TITLE
Fix ChatAnalyzer async launch

### DIFF
--- a/src/main/java/com/illusioncis7/opencore/OpenCore.java
+++ b/src/main/java/com/illusioncis7/opencore/OpenCore.java
@@ -289,7 +289,9 @@ public class OpenCore extends JavaPlugin {
         if (!moduleChatAnalyzer || chatAnalyzerTask == null) {
             return;
         }
-        getServer().getScheduler().runTaskAsynchronously(this, chatAnalyzerTask);
+        // schedule the existing BukkitRunnable using a simple Runnable wrapper
+        // to avoid IllegalStateException from rescheduling the same instance
+        getServer().getScheduler().runTaskAsynchronously(this, chatAnalyzerTask::run);
         restartChatAnalyzer();
     }
 


### PR DESCRIPTION
## Summary
- avoid scheduling a `BukkitRunnable` directly through the scheduler when running chat analysis on-demand
- wrap the existing task in a lambda to execute asynchronously

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846a80070a88323a7c98ec35b44fe27