### PR TITLE
Clamp change values from chat analysis

### DIFF
--- a/src/main/java/com/illusioncis7/opencore/reputation/ChatAnalyzerTask.java
+++ b/src/main/java/com/illusioncis7/opencore/reputation/ChatAnalyzerTask.java
@@ -82,10 +82,11 @@ public class ChatAnalyzerTask extends BukkitRunnable {
                         continue;
                     }
                     if (change < def.minChange || change > def.maxChange) {
-                        change = def.maxChange;
-                        logger.warning("Change out of bounds for flag " + flag + ": " + change + " | Set it to " + def.maxChange);
-                        continue;
+                        int clamped = Math.min(def.maxChange, Math.max(def.minChange, change));
+                        logger.warning("Change out of bounds for flag " + flag + ": " + change + " | Clamped to " + clamped);
+                        change = clamped;
                     }
+                    item.put("change", change);
                     UUID playerUuid = resolveAlias(alias);
                     if (playerUuid == null) continue;
                     perPlayer.computeIfAbsent(playerUuid, k -> new java.util.ArrayList<>()).add(item);


### PR DESCRIPTION
## Summary
- clamp out-of-range `change` values in ChatAnalyzerTask
- store the clamped value in the analysis data before adjusting reputation

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:2.6 or one of its dependencies could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_6846c32ae6c4832382b2d7723f26b3ce