### PR TITLE
Make GPT settings configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,19 @@ password: password
 
 OpenCore nutzt einen HikariCP-Pool mit zehn Verbindungen. Beim Start wird ein Ping ausgeführt und im Log ausgegeben.
 
+## GPT-Konfiguration
+Das GPT-Modul wird in `gpt.yml` eingestellt:
+
+```yml
+enabled: true
+api-key: "REPLACE-ME"
+interval-seconds: 600
+model: "gpt-3.5-turbo"
+temperature: 0.8
+```
+
+`model` bestimmt das zu verwendende OpenAI-Modell, `temperature` die Kreativität der Antworten.
+
 ## 🧠 Ziel
 Ein Server, der durch Spieler gesteuert, durch GPT unterstützt und durch klare Regeln geschützt wird.
 

--- a/src/main/java/com/illusioncis7/opencore/gpt/GptService.java
+++ b/src/main/java/com/illusioncis7/opencore/gpt/GptService.java
@@ -46,6 +46,8 @@ public class GptService {
     private int intervalSeconds;
     private boolean enabled;
     private boolean processing;
+    private String model;
+    private double temperature;
 
     public GptService(JavaPlugin plugin, Database database, PolicyService policyService) {
         this.plugin = plugin;
@@ -59,6 +61,8 @@ public class GptService {
         this.apiKey = config.getString("api-key", "");
         this.intervalSeconds = config.getInt("interval-seconds", 60);
         this.enabled = config.getBoolean("enabled", false);
+        this.model = config.getString("model", "gpt-3.5-turbo");
+        this.temperature = config.getDouble("temperature", 0.8);
 
         if (enabled) {
             new BukkitRunnable() {
@@ -189,13 +193,14 @@ public class GptService {
         logRequest(request);
 
         JSONObject payload = new JSONObject();
-        payload.put("model", "gpt-3.5-turbo");
+        payload.put("model", model);
         JSONArray messages = new JSONArray();
         JSONObject message = new JSONObject();
         message.put("role", "user");
         message.put("content", request.prompt);
         messages.put(message);
         payload.put("messages", messages);
+        payload.put("temperature", temperature);
 
         HttpRequest httpRequest = HttpRequest.newBuilder()
                 .uri(URI.create("https://api.openai.com/v1/chat/completions"))

--- a/src/main/resources/gpt.yml
+++ b/src/main/resources/gpt.yml
@@ -2,3 +2,5 @@
 enabled: true
 api-key: "REPLACE-ME"
 interval-seconds: 600
+model: "gpt-3.5-turbo"
+temperature: 0.8


### PR DESCRIPTION
## Summary
- add `model` and `temperature` to `gpt.yml`
- expose these settings in `GptService`
- document GPT options in README

## Testing
- `mvn -q test` *(fails: Could not resolve maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_6846e0f1ba6c832390da52fde4891f53