### PR TITLE
Switch GPT policies to file-based storage

### DIFF
--- a/gpt_policies/README_PLACEHOLDERS.md
+++ b/gpt_policies/README_PLACEHOLDERS.md
@@ -1,0 +1,16 @@
+# GPT Policy Placeholders
+
+Die folgenden Platzhalter werden in den Policy-Dateien verwendet und beim Erstellen des GPT-Prompts ersetzt.
+
+## chat_analysis
+- `%message%` – der zu analysierende Chatlog
+- `%rules%` – alle aktiven Serverregeln als Text
+- `%flags%` – Beschreibung aller Reputation-Flags
+
+## suggest_classify
+- `%s%` – der komplette Vorschlagstext
+- `%rules%` – aktuelle Serverregeln zur Einordnung
+
+## rule_map
+- `%s%` – der Vorschlagstext, der zu einer Regel werden soll
+- `%rules%` – bestehende Regeln zum Abgleich auf Konflikte

--- a/src/main/java/com/illusioncis7/opencore/OpenCore.java
+++ b/src/main/java/com/illusioncis7/opencore/OpenCore.java
@@ -96,12 +96,9 @@ public class OpenCore extends JavaPlugin {
 
         ruleService = new RuleService(this, database);
 
-        policyService = new PolicyService(this, database);
+        policyService = new PolicyService(this);
 
         setupManager = new com.illusioncis7.opencore.setup.SetupManager(this, ruleService, configService);
-        if (setupManager.isSetupActive()) {
-            policyService.ensureDefaults();
-        }
 
         gptService = new GptService(this, database, policyService);
         gptService.init();
@@ -258,6 +255,13 @@ public class OpenCore extends JavaPlugin {
 
     public MessageService getMessageService() {
         return messageService;
+    }
+
+    /** Reload policy files from disk. */
+    public void reloadPolicies() {
+        if (policyService != null) {
+            policyService.reload();
+        }
     }
 
     public com.illusioncis7.opencore.command.OpenCoreCommand getCoreCommand() {

--- a/src/main/java/com/illusioncis7/opencore/admin/ReloadCommand.java
+++ b/src/main/java/com/illusioncis7/opencore/admin/ReloadCommand.java
@@ -33,6 +33,7 @@ public class ReloadCommand implements TabExecutor {
             }
             OpenCore.getInstance().getCoreCommand().loadAliases();
             plugin.reloadModules();
+            plugin.reloadPolicies();
             plugin.reloadGptService();
             plugin.reloadChatAnalyzer();
             plugin.getMessageService().send(sender, "reload.success", null);

--- a/src/main/java/com/illusioncis7/opencore/gpt/GptService.java
+++ b/src/main/java/com/illusioncis7/opencore/gpt/GptService.java
@@ -109,7 +109,7 @@ public class GptService {
      * Placeholders of the form %key% are replaced with the provided values.
      */
     public String buildPrompt(String module, Map<String, String> values) {
-        String policy = policyService.getOrDefault(module);
+        String policy = policyService.getPolicy(module);
         if (policy == null) {
             return null;
         }


### PR DESCRIPTION
## Summary
- remove database usage from `PolicyService`
- load policy texts from `plugins/OpenCore/gpt_policies/*.txt`
- create missing policy files when the plugin loads
- reload policies during the `/opencore reload` command
- document placeholders in `gpt_policies/README_PLACEHOLDERS.md`

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e9560facc8323bce5ab0e6d2c0a4f