### PR TITLE
Add YAML chat flags and plugin

### DIFF
--- a/chatgpt-plugin/main.py
+++ b/chatgpt-plugin/main.py
@@ -1,0 +1,32 @@
+import os
+import yaml
+from fastapi import FastAPI
+
+app = FastAPI()
+
+CHAT_FLAGS_PATH = os.path.join("plugins", "OpenCore", "chat_flags.yml")
+
+
+def load_flags():
+    if not os.path.exists(CHAT_FLAGS_PATH):
+        return []
+    with open(CHAT_FLAGS_PATH, "r", encoding="utf-8") as f:
+        data = yaml.safe_load(f) or {}
+    result = []
+    for code, cfg in data.items():
+        if not isinstance(cfg, dict):
+            continue
+        if not cfg.get("active", True):
+            continue
+        result.append({
+            "code": code,
+            "description": cfg.get("description", ""),
+            "min_change": cfg.get("min_change", 0),
+            "max_change": cfg.get("max_change", 0),
+        })
+    return result
+
+
+@app.get("/flags")
+def get_flags():
+    return {"flags": load_flags()}

--- a/chatgpt-plugin/openapi.yaml
+++ b/chatgpt-plugin/openapi.yaml
@@ -1,0 +1,29 @@
+openapi: 3.0.1
+info:
+  title: OpenCore Flags API
+  version: '1.0.0'
+paths:
+  /flags:
+    get:
+      summary: List active chat reputation flags
+      responses:
+        '200':
+          description: Active flags
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  flags:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        code:
+                          type: string
+                        description:
+                          type: string
+                        min_change:
+                          type: integer
+                        max_change:
+                          type: integer

--- a/src/main/java/com/illusioncis7/opencore/OpenCore.java
+++ b/src/main/java/com/illusioncis7/opencore/OpenCore.java
@@ -89,7 +89,7 @@ public class OpenCore extends JavaPlugin {
         messageService = new MessageService(this);
 
         reputationService = new ReputationService(this, database);
-        chatFlagService = new ChatReputationFlagService(this, database);
+        chatFlagService = new ChatReputationFlagService(this);
 
         configService = new ConfigService(this, database);
         getLogger().info("Config parameters must be registered via the web interface.");

--- a/src/main/java/com/illusioncis7/opencore/database/Database.java
+++ b/src/main/java/com/illusioncis7/opencore/database/Database.java
@@ -150,16 +150,7 @@ public class Database {
                     ")";
             stmt.executeUpdate(guideSql);
 
-            String flagSql = "CREATE TABLE IF NOT EXISTS chat_reputation_flags (" +
-                    "id INT AUTO_INCREMENT PRIMARY KEY," +
-                    "code VARCHAR(50) NOT NULL," +
-                    "description TEXT," +
-                    "min_change INT NOT NULL," +
-                    "max_change INT NOT NULL," +
-                    "active BOOLEAN DEFAULT 1," +
-                    "last_updated TIMESTAMP NOT NULL" +
-                    ")";
-            stmt.executeUpdate(flagSql);
+
 
             String suggestionSql = "CREATE TABLE IF NOT EXISTS suggestions (" +
                     "id INT AUTO_INCREMENT PRIMARY KEY," +
@@ -307,16 +298,7 @@ public class Database {
                     ")";
             stmt.executeUpdate(guideSql);
 
-            String flagSql = "CREATE TABLE IF NOT EXISTS chat_reputation_flags (" +
-                    "id INTEGER PRIMARY KEY AUTOINCREMENT," +
-                    "code TEXT NOT NULL," +
-                    "description TEXT," +
-                    "min_change INT NOT NULL," +
-                    "max_change INT NOT NULL," +
-                    "active BOOLEAN DEFAULT 1," +
-                    "last_updated TIMESTAMP NOT NULL" +
-                    ")";
-            stmt.executeUpdate(flagSql);
+
 
             String suggestionSql = "CREATE TABLE IF NOT EXISTS suggestions (" +
                     "id INTEGER PRIMARY KEY AUTOINCREMENT," +

--- a/src/main/resources/chat_flags.yml
+++ b/src/main/resources/chat_flags.yml
@@ -1,0 +1,35 @@
+TOXICITY:
+  description: "Beleidigende, toxische oder eskalierende Wortwahl"
+  min_change: -3
+  max_change: -7
+  active: true
+
+SPAM:
+  description: "Wiederholende, inhaltslose oder störende Nachrichten"
+  min_change: -2
+  max_change: -4
+  active: true
+
+HELPFUL:
+  description: "Hilfreiche oder konstruktive Antworten im Chat"
+  min_change: 2
+  max_change: 5
+  active: true
+
+HATE_SPEECH:
+  description: "Rassistische, sexistische oder diskriminierende Sprache"
+  min_change: -5
+  max_change: -10
+  active: true
+
+FRIENDLY_TONE:
+  description: "Freundliche, respektvolle oder deeskalierende Sprache"
+  min_change: 1
+  max_change: 3
+  active: true
+
+MANIPULATION:
+  description: "Gespräche die offensichtlich zur Manipulation der Reputation dienen"
+  min_change: -1
+  max_change: -5
+  active: true


### PR DESCRIPTION
## Summary
- switch ChatReputationFlagService to YAML-based config
- remove creation of the old `chat_reputation_flags` DB table
- update OpenCore to use new service constructor
- add default `chat_flags.yml`
- provide a simple ChatGPT plugin exposing active flags

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e972c0e808323b5b890d143b367a1