### PR TITLE
Fix missing methods in ConfigParameter

### DIFF
--- a/src/main/java/com/illusioncis7/opencore/config/ConfigParameter.java
+++ b/src/main/java/com/illusioncis7/opencore/config/ConfigParameter.java
@@ -47,6 +47,22 @@ public class ConfigParameter {
         this.parameterPath = parameterPath;
     }
 
+    /**
+     * Convenience accessor used by the API layer. Returns the YAML
+     * path of this parameter as stored in the database.
+     */
+    public String getYamlPath() {
+        return parameterPath;
+    }
+
+    /**
+     * Indicates whether this parameter may be changed by players
+     * via the web panel or ingame commands.
+     */
+    public boolean isEditableByPlayers() {
+        return editable;
+    }
+
     public int getMinValue() {
         return minValue;
     }


### PR DESCRIPTION
## Summary
- implement `getYamlPath` and `isEditableByPlayers` in `ConfigParameter`

## Testing
- `mvn test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e9a0d03d88323adbfc93ec6944c26