### PR TITLE
Add web-based token service

### DIFF
--- a/src/main/java/com/illusioncis7/opencore/OpenCore.java
+++ b/src/main/java/com/illusioncis7/opencore/OpenCore.java
@@ -13,11 +13,13 @@ import com.illusioncis7.opencore.reputation.ChatReputationFlagService;
 import com.illusioncis7.opencore.voting.VotingService;
 import com.illusioncis7.opencore.voting.command.SuggestCommand;
 import com.illusioncis7.opencore.voting.command.SuggestionsCommand;
-import com.illusioncis7.opencore.voting.command.VoteCommand;
 import com.illusioncis7.opencore.voting.command.VoteStatusCommand;
 import com.illusioncis7.opencore.rules.RuleService;
 import com.illusioncis7.opencore.rules.command.RulesCommand;
 import com.illusioncis7.opencore.rules.command.EditRuleCommand;
+import com.illusioncis7.opencore.web.WebTokenService;
+import com.illusioncis7.opencore.web.command.SuggestionTokenCommand;
+import com.illusioncis7.opencore.web.command.VoteTokenCommand;
 import com.illusioncis7.opencore.config.command.RollbackConfigCommand;
 import com.illusioncis7.opencore.config.command.ConfigListCommand;
 import com.illusioncis7.opencore.admin.StatusCommand;
@@ -45,6 +47,7 @@ public class OpenCore extends JavaPlugin {
     private VotingService votingService;
     private PlanHook planHook;
     private MessageService messageService;
+    private WebTokenService webTokenService;
     private com.illusioncis7.opencore.command.OpenCoreCommand coreCommand;
     private com.illusioncis7.opencore.api.ApiServer apiServer;
     private com.illusioncis7.opencore.setup.SetupManager setupManager;
@@ -70,6 +73,7 @@ public class OpenCore extends JavaPlugin {
         saveResource("voting.yml", false);
         saveResource("api.yml", false);
         saveResource("messages.yml", false);
+        saveResource("opencore.yml", false);
         saveResource("webpanel/index.html", false);
         saveResource("modules.yml", false);
 
@@ -115,11 +119,14 @@ public class OpenCore extends JavaPlugin {
 
         votingService = new VotingService(this, database, gptService, configService, ruleService, reputationService, planHook);
 
+        webTokenService = new WebTokenService(this, database);
+
         SuggestCommand suggestCmd = new SuggestCommand(votingService);
 
         SuggestionsCommand listCmd = new SuggestionsCommand(votingService);
 
-        VoteCommand voteCmd = new VoteCommand(votingService);
+        SuggestionTokenCommand suggestionTokenCmd = new SuggestionTokenCommand(webTokenService);
+        VoteTokenCommand voteTokenCmd = new VoteTokenCommand(webTokenService);
         if (!moduleSuggestions) {
             getLogger().info("Suggestions module disabled via modules.yml");
         }
@@ -157,7 +164,8 @@ public class OpenCore extends JavaPlugin {
         coreCommand = new com.illusioncis7.opencore.command.OpenCoreCommand(this, messageService);
         coreCommand.register("suggest", suggestCmd);
         coreCommand.register("suggestions", listCmd);
-        coreCommand.register("vote", voteCmd);
+        coreCommand.register("suggestion", suggestionTokenCmd);
+        coreCommand.register("vote", voteTokenCmd);
         coreCommand.register("rules", rulesCmd);
         coreCommand.register("rollbackconfig", rollCmd);
         coreCommand.register("myrep", myRepCmd);

--- a/src/main/java/com/illusioncis7/opencore/database/Database.java
+++ b/src/main/java/com/illusioncis7/opencore/database/Database.java
@@ -229,6 +229,17 @@ public class Database {
                     "betroffene_spieler TEXT" +
                     ")";
             stmt.executeUpdate(analysisSql);
+
+            String tokenSql = "CREATE TABLE IF NOT EXISTS web_access_tokens (" +
+                    "id VARCHAR(36) PRIMARY KEY," +
+                    "player_uuid VARCHAR(36) NOT NULL," +
+                    "token TEXT NOT NULL," +
+                    "type VARCHAR(20) NOT NULL," +
+                    "issued_at TIMESTAMP NOT NULL," +
+                    "expires_at TIMESTAMP NOT NULL," +
+                    "used BOOLEAN DEFAULT 0" +
+                    ")";
+            stmt.executeUpdate(tokenSql);
         }
     }
 
@@ -377,6 +388,17 @@ public class Database {
                     "betroffene_spieler TEXT" +
                     ")";
             stmt.executeUpdate(analysisSql);
+
+            String tokenSql = "CREATE TABLE IF NOT EXISTS web_access_tokens (" +
+                    "id TEXT PRIMARY KEY," +
+                    "player_uuid TEXT NOT NULL," +
+                    "token TEXT NOT NULL," +
+                    "type TEXT NOT NULL," +
+                    "issued_at TIMESTAMP NOT NULL," +
+                    "expires_at TIMESTAMP NOT NULL," +
+                    "used BOOLEAN DEFAULT 0" +
+                    ")";
+            stmt.executeUpdate(tokenSql);
         }
     }
 

--- a/src/main/java/com/illusioncis7/opencore/web/WebTokenService.java
+++ b/src/main/java/com/illusioncis7/opencore/web/WebTokenService.java
@@ -1,0 +1,84 @@
+package com.illusioncis7.opencore.web;
+
+import com.illusioncis7.opencore.database.Database;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.io.File;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.Timestamp;
+import java.sql.SQLException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.UUID;
+
+public class WebTokenService {
+    private final JavaPlugin plugin;
+    private final Database database;
+
+    private String internalHost = "127.0.0.1";
+    private int internalPort = 8081;
+    private String publicUrl = "http://localhost:8081";
+    private int votePingIntervalMinutes = 60;
+    private int tokenValidityMinutes = 30;
+
+    public WebTokenService(JavaPlugin plugin, Database database) {
+        this.plugin = plugin;
+        this.database = database;
+        loadConfig();
+    }
+
+    private void loadConfig() {
+        File file = new File(plugin.getDataFolder(), "opencore.yml");
+        if (!file.exists()) {
+            plugin.saveResource("opencore.yml", false);
+        }
+        FileConfiguration cfg = YamlConfiguration.loadConfiguration(file);
+        ConfigurationSection sec = cfg.getConfigurationSection("web_interface");
+        if (sec != null) {
+            internalHost = sec.getString("internal_host", internalHost);
+            internalPort = sec.getInt("internal_port", internalPort);
+            publicUrl = sec.getString("public_url", publicUrl);
+            votePingIntervalMinutes = sec.getInt("vote_ping_interval_minutes", votePingIntervalMinutes);
+            tokenValidityMinutes = sec.getInt("token_validity_minutes", tokenValidityMinutes);
+        }
+    }
+
+    public String issueToken(UUID player, String type) {
+        if (!database.isConnected()) return null;
+        String id = UUID.randomUUID().toString();
+        String token = UUID.randomUUID().toString().replace("-", "");
+        Instant now = Instant.now();
+        Instant expires = now.plus(Duration.ofMinutes(tokenValidityMinutes));
+        String sql = "INSERT INTO web_access_tokens (id, player_uuid, token, type, issued_at, expires_at, used) VALUES (?, ?, ?, ?, ?, ?, 0)";
+        try (Connection conn = database.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setString(1, id);
+            ps.setString(2, player.toString());
+            ps.setString(3, token);
+            ps.setString(4, type);
+            ps.setTimestamp(5, Timestamp.from(now));
+            ps.setTimestamp(6, Timestamp.from(expires));
+            ps.executeUpdate();
+            return token;
+        } catch (SQLException e) {
+            plugin.getLogger().warning("Failed to store access token: " + e.getMessage());
+            return null;
+        }
+    }
+
+    public String getPublicUrl() {
+        return publicUrl;
+    }
+
+    public int getTokenValidityMinutes() {
+        return tokenValidityMinutes;
+    }
+
+    public int getVotePingIntervalMinutes() {
+        return votePingIntervalMinutes;
+    }
+}

--- a/src/main/java/com/illusioncis7/opencore/web/command/SuggestionTokenCommand.java
+++ b/src/main/java/com/illusioncis7/opencore/web/command/SuggestionTokenCommand.java
@@ -1,0 +1,49 @@
+package com.illusioncis7.opencore.web.command;
+
+import com.illusioncis7.opencore.OpenCore;
+import com.illusioncis7.opencore.web.WebTokenService;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabExecutor;
+import org.bukkit.entity.Player;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+public class SuggestionTokenCommand implements TabExecutor {
+    private final WebTokenService tokenService;
+
+    public SuggestionTokenCommand(WebTokenService tokenService) {
+        this.tokenService = tokenService;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!sender.hasPermission("opencore.command.suggestion")) {
+            OpenCore.getInstance().getMessageService().send(sender, "no_permission", null);
+            return true;
+        }
+        if (!(sender instanceof Player)) {
+            OpenCore.getInstance().getMessageService().send(sender, "suggest.players_only", null);
+            return true;
+        }
+        UUID uuid = ((Player) sender).getUniqueId();
+        String token = tokenService.issueToken(uuid, "suggestion");
+        if (token == null) {
+            OpenCore.getInstance().getMessageService().send(sender, "suggest.failed", null);
+            return true;
+        }
+        String url = tokenService.getPublicUrl() + "/suggest?token=" + token;
+        Map<String,String> ph = new HashMap<>();
+        ph.put("url", url);
+        OpenCore.getInstance().getMessageService().send(sender, "webtoken.suggestion", ph);
+        return true;
+    }
+
+    @Override
+    public java.util.List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+        return Collections.emptyList();
+    }
+}

--- a/src/main/java/com/illusioncis7/opencore/web/command/VoteTokenCommand.java
+++ b/src/main/java/com/illusioncis7/opencore/web/command/VoteTokenCommand.java
@@ -1,0 +1,49 @@
+package com.illusioncis7.opencore.web.command;
+
+import com.illusioncis7.opencore.OpenCore;
+import com.illusioncis7.opencore.web.WebTokenService;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabExecutor;
+import org.bukkit.entity.Player;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+public class VoteTokenCommand implements TabExecutor {
+    private final WebTokenService tokenService;
+
+    public VoteTokenCommand(WebTokenService tokenService) {
+        this.tokenService = tokenService;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!sender.hasPermission("opencore.command.vote")) {
+            OpenCore.getInstance().getMessageService().send(sender, "no_permission", null);
+            return true;
+        }
+        if (!(sender instanceof Player)) {
+            OpenCore.getInstance().getMessageService().send(sender, "vote.players_only", null);
+            return true;
+        }
+        UUID uuid = ((Player) sender).getUniqueId();
+        String token = tokenService.issueToken(uuid, "vote");
+        if (token == null) {
+            OpenCore.getInstance().getMessageService().send(sender, "vote.unknown", null);
+            return true;
+        }
+        String url = tokenService.getPublicUrl() + "/vote?token=" + token;
+        Map<String,String> ph = new HashMap<>();
+        ph.put("url", url);
+        OpenCore.getInstance().getMessageService().send(sender, "webtoken.vote", ph);
+        return true;
+    }
+
+    @Override
+    public java.util.List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+        return Collections.emptyList();
+    }
+}

--- a/src/main/resources/command-aliases.yml
+++ b/src/main/resources/command-aliases.yml
@@ -3,6 +3,8 @@ aliases:
     - vorschlag
   suggestions:
     - vorschlaege
+  suggestion:
+    - vorschlaglink
   vote:
     - abstimmen
   rules:

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -123,3 +123,6 @@ join:
   module_disabled: "&cDieses Modul ist deaktiviert."
 chatanalyze:
   started: "&aChat-Analyse wird ausgef\u00FChrt."
+webtoken:
+  suggestion: "&aVorschlagslink: {url}"
+  vote: "&aAbstimmungslink: {url}"

--- a/src/main/resources/opencore.yml
+++ b/src/main/resources/opencore.yml
@@ -1,0 +1,6 @@
+web_interface:
+  internal_host: 127.0.0.1
+  internal_port: 8081
+  public_url: "https://web.freibau-smp.de"
+  vote_ping_interval_minutes: 60
+  token_validity_minutes: 30


### PR DESCRIPTION
## Summary
- create WebTokenService for issuing temporary tokens
- add commands for suggestion and vote tokens
- register token commands in plugin main class
- store tokens in new `web_access_tokens` table
- update messages and command aliases
- add default `opencore.yml`

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ea1bfa3e48323ba1ab1369b01d23b