### PR TITLE
Implement web voting UI & API

### DIFF
--- a/src/main/java/com/illusioncis7/opencore/OpenCore.java
+++ b/src/main/java/com/illusioncis7/opencore/OpenCore.java
@@ -48,6 +48,8 @@ public class OpenCore extends JavaPlugin {
     private PlanHook planHook;
     private MessageService messageService;
     private WebTokenService webTokenService;
+    private com.illusioncis7.opencore.web.SuggestionCommentService commentService;
+    private com.illusioncis7.opencore.web.WebInterfaceServer webInterfaceServer;
     private com.illusioncis7.opencore.command.OpenCoreCommand coreCommand;
     private com.illusioncis7.opencore.api.ApiServer apiServer;
     private com.illusioncis7.opencore.setup.SetupManager setupManager;
@@ -75,6 +77,8 @@ public class OpenCore extends JavaPlugin {
         saveResource("messages.yml", false);
         saveResource("opencore.yml", false);
         saveResource("webpanel/index.html", false);
+        saveResource("webpanel/suggest.html", false);
+        saveResource("webpanel/vote.html", false);
         saveResource("modules.yml", false);
 
         org.bukkit.configuration.file.FileConfiguration modCfg =
@@ -120,6 +124,12 @@ public class OpenCore extends JavaPlugin {
         votingService = new VotingService(this, database, gptService, configService, ruleService, reputationService, planHook);
 
         webTokenService = new WebTokenService(this, database);
+        commentService = new com.illusioncis7.opencore.web.SuggestionCommentService(this, database);
+        try {
+            webInterfaceServer = new com.illusioncis7.opencore.web.WebInterfaceServer(webTokenService, votingService, commentService, getLogger());
+        } catch (Exception e) {
+            getLogger().warning("Failed to start web interface: " + e.getMessage());
+        }
 
         SuggestCommand suggestCmd = new SuggestCommand(votingService);
 
@@ -230,6 +240,9 @@ public class OpenCore extends JavaPlugin {
         }
         if (apiServer != null) {
             apiServer.stop();
+        }
+        if (webInterfaceServer != null) {
+            webInterfaceServer.stop();
         }
     }
 

--- a/src/main/java/com/illusioncis7/opencore/database/Database.java
+++ b/src/main/java/com/illusioncis7/opencore/database/Database.java
@@ -160,12 +160,26 @@ public class Database {
                     "text TEXT," +
                     "created TIMESTAMP NOT NULL," +
                     "open BOOLEAN DEFAULT 1," +
+                    "expired BOOLEAN DEFAULT 0," +
                     "suggestion_type ENUM('CONFIG_CHANGE','RULE_CHANGE','MODERATION_REQUEST','FEATURE_REQUEST','BUG_REPORT','EVENT_PROPOSAL','OTHER')," +
                     "gpt_reasoning TEXT," +
                     "gpt_confidence FLOAT," +
                     "classified_at TIMESTAMP" +
                     ")";
             stmt.executeUpdate(suggestionSql);
+
+            String commentSql = "CREATE TABLE IF NOT EXISTS suggestion_comments (" +
+                    "id INT AUTO_INCREMENT PRIMARY KEY," +
+                    "suggestion_id INT NOT NULL," +
+                    "player_uuid VARCHAR(36) NOT NULL," +
+                    "content TEXT NOT NULL," +
+                    "timestamp TIMESTAMP NOT NULL" +
+                    ")";
+            stmt.executeUpdate(commentSql);
+
+            try { stmt.executeUpdate("ALTER TABLE suggestions ADD COLUMN expired BOOLEAN DEFAULT 0"); } catch (SQLException ignore) {}
+
+            try { stmt.executeUpdate("ALTER TABLE suggestions ADD COLUMN expired BOOLEAN DEFAULT 0"); } catch (SQLException ignore) {}
 
             String voteSql = "CREATE TABLE IF NOT EXISTS votes (" +
                     "id INT AUTO_INCREMENT PRIMARY KEY," +
@@ -319,12 +333,22 @@ public class Database {
                     "text TEXT," +
                     "created TIMESTAMP NOT NULL," +
                     "open BOOLEAN DEFAULT 1," +
+                    "expired BOOLEAN DEFAULT 0," +
                     "suggestion_type TEXT," +
                     "gpt_reasoning TEXT," +
                     "gpt_confidence FLOAT," +
                     "classified_at TIMESTAMP" +
                     ")";
             stmt.executeUpdate(suggestionSql);
+
+            String commentSql = "CREATE TABLE IF NOT EXISTS suggestion_comments (" +
+                    "id INTEGER PRIMARY KEY AUTOINCREMENT," +
+                    "suggestion_id INT NOT NULL," +
+                    "player_uuid TEXT NOT NULL," +
+                    "content TEXT NOT NULL," +
+                    "timestamp TIMESTAMP NOT NULL" +
+                    ")";
+            stmt.executeUpdate(commentSql);
 
             String voteSql = "CREATE TABLE IF NOT EXISTS votes (" +
                     "id INTEGER PRIMARY KEY AUTOINCREMENT," +

--- a/src/main/java/com/illusioncis7/opencore/voting/Suggestion.java
+++ b/src/main/java/com/illusioncis7/opencore/voting/Suggestion.java
@@ -12,9 +12,10 @@ public class Suggestion {
     public final String text;
     public final Instant created;
     public final boolean open;
+    public final boolean expired;
 
     public Suggestion(int id, UUID playerUuid, int parameterId, String newValue, String description, String text,
-                      Instant created, boolean open) {
+                      Instant created, boolean open, boolean expired) {
         this.id = id;
         this.playerUuid = playerUuid;
         this.parameterId = parameterId;
@@ -23,5 +24,6 @@ public class Suggestion {
         this.text = text;
         this.created = created;
         this.open = open;
+        this.expired = expired;
     }
 }

--- a/src/main/java/com/illusioncis7/opencore/web/SuggestionCommentService.java
+++ b/src/main/java/com/illusioncis7/opencore/web/SuggestionCommentService.java
@@ -1,0 +1,72 @@
+package com.illusioncis7.opencore.web;
+
+import com.illusioncis7.opencore.database.Database;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.sql.*;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+public class SuggestionCommentService {
+    public static class Comment {
+        public final int id;
+        public final int suggestionId;
+        public final UUID player;
+        public final String content;
+        public final Instant created;
+        public Comment(int id, int suggestionId, UUID player, String content, Instant created) {
+            this.id = id;
+            this.suggestionId = suggestionId;
+            this.player = player;
+            this.content = content;
+            this.created = created;
+        }
+    }
+
+    private final JavaPlugin plugin;
+    private final Database database;
+
+    public SuggestionCommentService(JavaPlugin plugin, Database database) {
+        this.plugin = plugin;
+        this.database = database;
+    }
+
+    public void addComment(int suggestionId, UUID player, String content) {
+        if (!database.isConnected()) return;
+        String sql = "INSERT INTO suggestion_comments (suggestion_id, player_uuid, content, timestamp) VALUES (?, ?, ?, ?)";
+        try (Connection conn = database.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setInt(1, suggestionId);
+            ps.setString(2, player.toString());
+            ps.setString(3, content);
+            ps.setTimestamp(4, Timestamp.from(Instant.now()));
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            plugin.getLogger().warning("Failed to add comment: " + e.getMessage());
+        }
+    }
+
+    public List<Comment> getComments(int suggestionId) {
+        List<Comment> list = new ArrayList<>();
+        if (!database.isConnected()) return list;
+        String sql = "SELECT id, player_uuid, content, timestamp FROM suggestion_comments WHERE suggestion_id = ? ORDER BY timestamp";
+        try (Connection conn = database.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setInt(1, suggestionId);
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    int id = rs.getInt(1);
+                    UUID player = UUID.fromString(rs.getString(2));
+                    String content = rs.getString(3);
+                    Instant ts = rs.getTimestamp(4).toInstant();
+                    list.add(new Comment(id, suggestionId, player, content, ts));
+                }
+            }
+        } catch (SQLException e) {
+            plugin.getLogger().warning("Failed to load comments: " + e.getMessage());
+        }
+        return list;
+    }
+}

--- a/src/main/java/com/illusioncis7/opencore/web/WebInterfaceServer.java
+++ b/src/main/java/com/illusioncis7/opencore/web/WebInterfaceServer.java
@@ -1,0 +1,189 @@
+package com.illusioncis7.opencore.web;
+
+import com.illusioncis7.opencore.voting.Suggestion;
+import com.illusioncis7.opencore.voting.VotingService;
+import com.illusioncis7.opencore.web.SuggestionCommentService.Comment;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.UUID;
+import java.util.logging.Logger;
+
+/**
+ * Lightweight web API for suggestions and voting.
+ */
+public class WebInterfaceServer {
+    private final WebTokenService tokenService;
+    private final VotingService votingService;
+    private final SuggestionCommentService commentService;
+    private final Logger logger;
+    private HttpServer server;
+
+    public WebInterfaceServer(WebTokenService tokenService, VotingService votingService,
+                              SuggestionCommentService commentService, Logger logger) throws IOException {
+        this.tokenService = tokenService;
+        this.votingService = votingService;
+        this.commentService = commentService;
+        this.logger = logger;
+        server = HttpServer.create(new InetSocketAddress(tokenService.getInternalHost(), tokenService.getInternalPort()), 0);
+        registerContexts();
+        server.start();
+        logger.info("Web interface listening on " + tokenService.getInternalHost() + ":" + tokenService.getInternalPort());
+    }
+
+    private void registerContexts() {
+        server.createContext("/validate-token", this::handleValidateToken);
+        server.createContext("/suggestions", this::handleSuggestions);
+        server.createContext("/submit-suggestion", this::handleSubmitSuggestion);
+        server.createContext("/cast-vote", this::handleCastVote);
+        server.createContext("/suggestion-comments", this::handleComments);
+    }
+
+    public void stop() {
+        if (server != null) server.stop(0);
+    }
+
+    private void handleValidateToken(HttpExchange ex) throws IOException {
+        if (!"POST".equalsIgnoreCase(ex.getRequestMethod())) { ex.sendResponseHeaders(405, -1); return; }
+        JSONObject req = readJson(ex);
+        String token = req.optString("token", null);
+        String type = req.optString("type", null);
+        UUID player = tokenService.validateToken(token, type);
+        JSONObject resp = new JSONObject();
+        resp.put("valid", player != null);
+        if (player != null) resp.put("player", player.toString());
+        writeJson(ex, resp);
+    }
+
+    private void handleSuggestions(HttpExchange ex) throws IOException {
+        String token = getParam(ex, "token");
+        if (tokenService.checkToken(token) == null) { ex.sendResponseHeaders(403, -1); return; }
+        JSONArray arr = new JSONArray();
+        for (Suggestion s : votingService.getOpenSuggestions()) {
+            VotingService.VoteWeights w = votingService.getVoteWeights(s.id);
+            JSONObject o = new JSONObject();
+            o.put("id", s.id);
+            o.put("text", s.text);
+            if (s.description != null) o.put("description", s.description);
+            o.put("player", s.playerUuid.toString());
+            o.put("remaining", votingService.getRemainingMinutes(s.created));
+            o.put("yes", w.yesWeight);
+            o.put("no", w.noWeight);
+            o.put("required", w.requiredWeight);
+            o.put("expired", false);
+            arr.put(o);
+        }
+        for (Suggestion s : votingService.getClosedSuggestions()) {
+            if (!s.expired) continue;
+            VotingService.VoteWeights w = votingService.getVoteWeights(s.id);
+            JSONObject o = new JSONObject();
+            o.put("id", s.id);
+            o.put("text", s.text);
+            if (s.description != null) o.put("description", s.description);
+            o.put("player", s.playerUuid.toString());
+            o.put("remaining", 0);
+            o.put("yes", w.yesWeight);
+            o.put("no", w.noWeight);
+            o.put("required", w.requiredWeight);
+            o.put("expired", true);
+            arr.put(o);
+        }
+        writeJson(ex, new JSONObject().put("suggestions", arr));
+    }
+
+    private void handleSubmitSuggestion(HttpExchange ex) throws IOException {
+        if (!"POST".equalsIgnoreCase(ex.getRequestMethod())) { ex.sendResponseHeaders(405, -1); return; }
+        JSONObject req = readJson(ex);
+        String token = req.optString("token", null);
+        UUID player = tokenService.checkToken(token);
+        if (player == null) { ex.sendResponseHeaders(403, -1); return; }
+        int paramId = req.optInt("parameter", -1);
+        String value = req.optString("value", null);
+        String reason = req.optString("reason", "");
+        if (paramId <= 0 || value == null || reason.isEmpty()) { ex.sendResponseHeaders(400, -1); return; }
+        int id = votingService.submitDirectSuggestion(player, paramId, value, reason);
+        JSONObject resp = new JSONObject();
+        resp.put("id", id);
+        writeJson(ex, resp);
+    }
+
+    private void handleCastVote(HttpExchange ex) throws IOException {
+        if (!"POST".equalsIgnoreCase(ex.getRequestMethod())) { ex.sendResponseHeaders(405, -1); return; }
+        JSONObject req = readJson(ex);
+        String token = req.optString("token", null);
+        UUID player = tokenService.checkToken(token);
+        if (player == null) { ex.sendResponseHeaders(403, -1); return; }
+        int suggestion = req.optInt("suggestion", -1);
+        String vote = req.optString("vote", "");
+        boolean ok = true;
+        if ("yes".equalsIgnoreCase(vote)) ok = votingService.castVote(player, suggestion, true);
+        else if ("no".equalsIgnoreCase(vote)) ok = votingService.castVote(player, suggestion, false);
+        JSONObject resp = new JSONObject();
+        resp.put("success", ok);
+        writeJson(ex, resp);
+    }
+
+    private void handleComments(HttpExchange ex) throws IOException {
+        if ("GET".equalsIgnoreCase(ex.getRequestMethod())) {
+            String token = getParam(ex, "token");
+            if (tokenService.checkToken(token) == null) { ex.sendResponseHeaders(403, -1); return; }
+            int id = Integer.parseInt(getParam(ex, "suggestion"));
+            List<Comment> list = commentService.getComments(id);
+            JSONArray arr = new JSONArray();
+            for (Comment c : list) {
+                JSONObject o = new JSONObject();
+                o.put("player", c.player.toString());
+                o.put("content", c.content);
+                o.put("timestamp", c.created.toString());
+                arr.put(o);
+            }
+            writeJson(ex, new JSONObject().put("comments", arr));
+        } else if ("POST".equalsIgnoreCase(ex.getRequestMethod())) {
+            JSONObject req = readJson(ex);
+            String token = req.optString("token", null);
+            UUID player = tokenService.checkToken(token);
+            if (player == null) { ex.sendResponseHeaders(403, -1); return; }
+            int id = req.optInt("suggestion", -1);
+            String content = req.optString("content", "");
+            if (id <= 0 || content.isEmpty()) { ex.sendResponseHeaders(400, -1); return; }
+            commentService.addComment(id, player, content);
+            writeJson(ex, new JSONObject().put("success", true));
+        } else {
+            ex.sendResponseHeaders(405, -1);
+        }
+    }
+
+    private JSONObject readJson(HttpExchange ex) throws IOException {
+        try (InputStream is = ex.getRequestBody()) {
+            byte[] data = is.readAllBytes();
+            return new JSONObject(new String(data, StandardCharsets.UTF_8));
+        }
+    }
+
+    private void writeJson(HttpExchange ex, JSONObject obj) throws IOException {
+        byte[] data = obj.toString().getBytes(StandardCharsets.UTF_8);
+        ex.getResponseHeaders().add("Content-Type", "application/json");
+        ex.sendResponseHeaders(200, data.length);
+        try (OutputStream os = ex.getResponseBody()) {
+            os.write(data);
+        }
+    }
+
+    private String getParam(HttpExchange ex, String key) {
+        String q = ex.getRequestURI().getRawQuery();
+        if (q == null) return null;
+        for (String p : q.split("&")) {
+            String[] kv = p.split("=");
+            if (kv.length == 2 && kv[0].equals(key)) return java.net.URLDecoder.decode(kv[1], StandardCharsets.UTF_8);
+        }
+        return null;
+    }
+}

--- a/src/main/resources/webpanel/suggest.html
+++ b/src/main/resources/webpanel/suggest.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html><head><meta charset="UTF-8"><title>Suggest</title></head>
+<body>
+<h2>Neuer Vorschlag</h2>
+<label>Parameter ID: <input id="param"></label><br/>
+<label>Neuer Wert: <input id="value"></label><br/>
+<label>Begründung:<br/><textarea id="reason"></textarea></label><br/>
+<button onclick="submit()">Absenden</button>
+<script>
+const token=new URLSearchParams(location.search).get('token');
+async function submit(){
+  const r=await fetch('/submit-suggestion',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({token:token,parameter:parseInt(document.getElementById('param').value),value:document.getElementById('value').value,reason:document.getElementById('reason').value})});
+  const j=await r.json();
+  alert('Gesendet, ID '+j.id);
+}
+</script>
+</body></html>

--- a/src/main/resources/webpanel/vote.html
+++ b/src/main/resources/webpanel/vote.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html><head><meta charset="UTF-8"><title>Vote</title></head>
+<body>
+<h2>Abstimmungen</h2>
+<div id="list">Lade...</div>
+<script>
+const token=new URLSearchParams(location.search).get('token');
+async function load(){
+ const r=await fetch('/suggestions?token='+encodeURIComponent(token));
+ const j=await r.json();
+ const div=document.getElementById('list');
+ div.innerHTML='';
+ j.suggestions.forEach(s=>{
+   const d=document.createElement('div');
+   d.innerHTML='<h3>'+s.text+'</h3><p>'+(s.description||'')+'</p>'+
+     '<p>Stimmen: '+s.yes+'/'+s.no+' (benötigt '+s.required+')</p>'+
+     (s.expired?'<b>Verfallen</b><br/>':'')+
+     '<button onclick="vote('+s.id+',true)">Ja</button> '+
+     '<button onclick="vote('+s.id+',false)">Nein</button>';
+   div.appendChild(d);
+ });
+}
+async function vote(id,yes){
+ await fetch('/cast-vote',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({token:token,suggestion:id,vote:yes?'yes':'no'})});
+ load();
+}
+load();
+</script>
+</body></html>


### PR DESCRIPTION
## Summary
- create WebInterfaceServer with REST endpoints
- manage suggestion comments in database
- extend WebTokenService with validation and cleanup
- add support for expired suggestions
- expose new web pages for voting and suggestions

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ea54f8de08323865e0307e00d7842