### PR TITLE
Add token checks and web UI enhancements

### DIFF
--- a/src/main/java/com/illusioncis7/opencore/OpenCore.java
+++ b/src/main/java/com/illusioncis7/opencore/OpenCore.java
@@ -129,7 +129,8 @@ public class OpenCore extends JavaPlugin {
         commentService = new com.illusioncis7.opencore.web.SuggestionCommentService(this, database);
         try {
             webInterfaceServer = new com.illusioncis7.opencore.web.WebInterfaceServer(
-                    webTokenService, votingService, commentService, ruleService, configService, getLogger());
+                    webTokenService, votingService, commentService, ruleService, configService,
+                    reputationService, getLogger());
         } catch (Exception e) {
             getLogger().warning("Failed to start web interface: " + e.getMessage());
         }

--- a/src/main/resources/webpanel/admin.html
+++ b/src/main/resources/webpanel/admin.html
@@ -11,6 +11,7 @@ th,td{border:1px solid #ccc;padding:4px;}
 </head>
 <body>
 <h1>OpenCore Admin Panel</h1>
+<div id="userinfo"></div>
 <h2>Regeln</h2>
 <div id="rules">Lade...</div>
 <input id="ruleText" placeholder="Regeltext"/>
@@ -18,9 +19,15 @@ th,td{border:1px solid #ccc;padding:4px;}
 <button onclick="addRule()">Hinzufügen</button>
 <h2>Konfiguration</h2>
 <div id="configs">Lade...</div>
+<h3>Neuer Parameter</h3>
+<input id="cfgPath" placeholder="Dateipfad"/>
+<input id="cfgParam" placeholder="Parameter"/>
+<input id="cfgValue" placeholder="Wert"/>
+<button onclick="addConfig()">Hinzufügen</button>
 <script>
 const token=new URLSearchParams(location.search).get('token');
 async function fetchJson(u,opt){const r=await fetch(u,opt);return r.ok?r.json():{};}
+async function validate(){const r=await fetch('/validate-token',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({token:token,type:'admin'})});const j=await r.json();if(!j.valid){document.body.innerText='Token ungültig';return false;}document.getElementById('userinfo').innerText=j.name+' (Rep '+j.reputation+')';return true;}
 async function loadRules(){const j=await fetchJson('/admin/rules?token='+encodeURIComponent(token));const div=document.getElementById('rules');div.innerHTML='';(j.rules||[]).forEach(r=>{const row=document.createElement('div');row.innerHTML='<input size="60" value="'+r.text+'"> <input value="'+(r.category||'')+'"> <button>Speichern</button> <button>Löschen</button>';const t=row.querySelector('input');const c=row.querySelectorAll('input')[1];row.querySelector('button').onclick=()=>updateRule(r.id,t.value,c.value);row.querySelectorAll('button')[1].onclick=()=>{deleteRule(r.id);row.remove();};div.appendChild(row);});}
 async function addRule(){const t=document.getElementById('ruleText').value;const c=document.getElementById('ruleCat').value;if(!t)return;await fetch('/admin/rules/add',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({token:token,text:t,category:c})});loadRules();}
 async function updateRule(id,t,c){await fetch('/admin/rules/update',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({token:token,id:id,text:t,category:c})});}
@@ -28,7 +35,8 @@ async function deleteRule(id){await fetch('/admin/rules/delete',{method:'POST',h
 async function loadConfigs(){const j=await fetchJson('/admin/configs?token='+encodeURIComponent(token));const div=document.getElementById('configs');div.innerHTML='';const table=document.createElement('table');div.appendChild(table);const head=document.createElement('tr');head.innerHTML='<th>Name</th><th>Wert</th><th></th><th></th>';table.appendChild(head);(j.parameters||[]).forEach(p=>{const tr=document.createElement('tr');tr.innerHTML='<td>'+p.name+'</td><td><input value="'+(p.value||'')+'"></td><td><button>Speichern</button></td><td><button>Löschen</button></td>';const inp=tr.querySelector('input');tr.querySelector('button').onclick=()=>updateConfig(p.id,inp.value);tr.querySelectorAll('button')[1].onclick=()=>{deleteConfig(p.id);tr.remove();};table.appendChild(tr);});}
 async function updateConfig(id,v){await fetch('/admin/configs/update',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({token:token,id:id,value:v})});}
 async function deleteConfig(id){await fetch('/admin/configs/delete',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({token:token,id:id})});}
-loadRules();loadConfigs();
+async function addConfig(){const path=document.getElementById('cfgPath').value;const p=document.getElementById('cfgParam').value;const val=document.getElementById('cfgValue').value;if(!path||!p)return;await fetch('/admin/configs/add',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({token:token,path:path,parameter:p,current:val})});loadConfigs();}
+validate().then(ok=>{if(ok){loadRules();loadConfigs();}});
 </script>
 </body>
 </html>

--- a/src/main/resources/webpanel/suggest.html
+++ b/src/main/resources/webpanel/suggest.html
@@ -1,17 +1,25 @@
 <!DOCTYPE html>
 <html><head><meta charset="UTF-8"><title>Suggest</title></head>
 <body>
+<div id="userinfo"></div>
 <h2>Neuer Vorschlag</h2>
-<label>Parameter ID: <input id="param"></label><br/>
+<h3>Regeln</h3>
+<ul id="rules"></ul>
+<h3>Konfigurationsparameter</h3>
+<select id="param"></select><br/>
 <label>Neuer Wert: <input id="value"></label><br/>
 <label>Begründung:<br/><textarea id="reason"></textarea></label><br/>
 <button onclick="submit()">Absenden</button>
 <script>
 const token=new URLSearchParams(location.search).get('token');
+async function validate(){const r=await fetch('/validate-token',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({token:token,type:'suggestion'})});const j=await r.json();if(!j.valid){document.body.innerText='Token ungültig';return false;}document.getElementById('userinfo').innerText=j.name+' (Rep '+j.reputation+')';return true;}
+async function loadRules(){const r=await fetch('/rules?token='+encodeURIComponent(token));const j=await r.json();const ul=document.getElementById('rules');ul.innerHTML='';(j.rules||[]).forEach(rr=>{const li=document.createElement('li');li.textContent=rr.text;ul.appendChild(li);});}
+async function loadConfigs(){const r=await fetch('/configs?token='+encodeURIComponent(token));const j=await r.json();const sel=document.getElementById('param');sel.innerHTML='';(j.parameters||[]).forEach(p=>{const o=document.createElement('option');o.value=p.id;o.textContent=p.name;sel.appendChild(o);});}
 async function submit(){
   const r=await fetch('/submit-suggestion',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({token:token,parameter:parseInt(document.getElementById('param').value),value:document.getElementById('value').value,reason:document.getElementById('reason').value})});
   const j=await r.json();
   alert('Gesendet, ID '+j.id);
 }
+validate().then(ok=>{if(ok){loadRules();loadConfigs();}});
 </script>
 </body></html>

--- a/src/main/resources/webpanel/vote.html
+++ b/src/main/resources/webpanel/vote.html
@@ -1,10 +1,12 @@
 <!DOCTYPE html>
 <html><head><meta charset="UTF-8"><title>Vote</title></head>
 <body>
+<div id="userinfo"></div>
 <h2>Abstimmungen</h2>
 <div id="list">Lade...</div>
 <script>
 const token=new URLSearchParams(location.search).get('token');
+async function validate(){const r=await fetch('/validate-token',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({token:token,type:'vote'})});const j=await r.json();if(!j.valid){document.body.innerText='Token ungültig';return false;}document.getElementById('userinfo').innerText=j.name+' (Rep '+j.reputation+')';return true;}
 async function load(){
  const r=await fetch('/suggestions?token='+encodeURIComponent(token));
  const j=await r.json();
@@ -24,6 +26,6 @@ async function vote(id,yes){
  await fetch('/cast-vote',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({token:token,suggestion:id,vote:yes?'yes':'no'})});
  load();
 }
-load();
+validate().then(ok=>{if(ok){load();}});
 </script>
 </body></html>


### PR DESCRIPTION
## Summary
- verify token type in all web routes
- expose `/rules` and `/configs` endpoints
- include player name and reputation when validating tokens
- update web admin panel with token validation and add config feature
- show rules and configuration options on suggestion page
- display token user info on vote page

## Testing
- `mvn -q test` *(fails: PluginResolutionException)*

------
https://chatgpt.com/codex/tasks/task_e_684eb0c401108323a1c77a1b6a922f2c